### PR TITLE
#163518696 Pagination support when fetching the articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 
+# Vscode directory
+.vscode
+
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 

--- a/controllers/articleLikesController.js
+++ b/controllers/articleLikesController.js
@@ -18,11 +18,7 @@ export default class ArticleLikesController {
   static async like(req, res) {
     const { slug } = req.params;
     try {
-      const article = await Article.findOne({
-        where: {
-          slug
-        }
-      });
+      const article = await Article.findOne({ where: { slug } });
       if (!article) {
         return res.status(NOT_FOUND).json({
           message: "Article not found"
@@ -46,12 +42,7 @@ export default class ArticleLikesController {
         }
         await ArticleLike.update(
           { like: true },
-          {
-            where: {
-              userId: req.user.id,
-              articleId: article.id
-            }
-          }
+          { where: { userId: req.user.id, articleId: article.id } }
         );
         return res.status(OK).json({ message: "Successfully liked" });
       });
@@ -65,6 +56,7 @@ export default class ArticleLikesController {
 
   /**
    * @description let user dislike article
+   * @param {object} -req The request object
    * @param {object} -res The response object
    * @return {object} - returns the response object
    */
@@ -72,21 +64,12 @@ export default class ArticleLikesController {
   static async dislike(req, res) {
     const { slug } = req.params;
     try {
-      const article = await Article.findOne({
-        where: {
-          slug
-        }
-      });
+      const article = await Article.findOne({ where: { slug } });
       if (!article) {
-        return res.status(NOT_FOUND).json({
-          message: "Article not found"
-        });
+        return res.status(NOT_FOUND).json({ message: "Article not found" });
       }
       await ArticleLike.findOrCreate({
-        where: {
-          userId: req.user.id,
-          articleId: article.id
-        },
+        where: { userId: req.user.id, articleId: article.id },
         defaults: { like: false }
       }).spread(async (articleLike, created) => {
         if (created) {
@@ -94,21 +77,13 @@ export default class ArticleLikesController {
         }
         if (!articleLike.like) {
           await ArticleLike.destroy({
-            where: {
-              userId: req.user.id,
-              articleId: article.id
-            }
+            where: { userId: req.user.id, articleId: article.id }
           });
           return res.status(OK).json({ message: "Successfully removed dislike" });
         }
         await ArticleLike.update(
           { like: false },
-          {
-            where: {
-              userId: req.user.id,
-              articleId: article.id
-            }
-          }
+          { where: { userId: req.user.id, articleId: article.id } }
         );
         return res.status(CREATED).json({ message: "Successfully disliked" });
       });
@@ -130,9 +105,7 @@ export default class ArticleLikesController {
     const { slug } = req.params;
     try {
       const article = await Article.findOne({
-        where: {
-          slug
-        },
+        where: { slug },
         include: [
           {
             model: User,
@@ -152,12 +125,11 @@ export default class ArticleLikesController {
       if (!article) {
         return res.status(NOT_FOUND).json({ message: "Article not found" });
       }
-
-      res.json({ article });
+      return res.status(OK).json({ article });
     } catch (err) {
       res.status(INTERNAL_SERVER_ERROR).json({
-        message:
-          "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
+        message: "Unknown error",
+        errors: err.stack
       });
     }
   }

--- a/controllers/articleLikesController.js
+++ b/controllers/articleLikesController.js
@@ -39,10 +39,20 @@ export default class ArticleLikesController {
           return res.status(CREATED).json({ message: "Successfully liked" });
         }
         if (articleLike.like) {
-          await articleLike.destroy();
-          return res.status(OK).json({ message: "Unliked successfully" });
+          await ArticleLike.destroy({
+            where: { userId: req.user.id, articleId: article.id }
+          });
+          return res.status(OK).json({ message: "Disliked successfully" });
         }
-        await articleLike.update({ like: true });
+        await ArticleLike.update(
+          { like: true },
+          {
+            where: {
+              userId: req.user.id,
+              articleId: article.id
+            }
+          }
+        );
         return res.status(OK).json({ message: "Successfully liked" });
       });
     } catch (err) {
@@ -83,10 +93,23 @@ export default class ArticleLikesController {
           return res.status(CREATED).json({ message: "Successfully disliked" });
         }
         if (!articleLike.like) {
-          await articleLike.destroy();
+          await ArticleLike.destroy({
+            where: {
+              userId: req.user.id,
+              articleId: article.id
+            }
+          });
           return res.status(OK).json({ message: "Successfully removed dislike" });
         }
-        await articleLike.update({ like: false });
+        await ArticleLike.update(
+          { like: false },
+          {
+            where: {
+              userId: req.user.id,
+              articleId: article.id
+            }
+          }
+        );
         return res.status(CREATED).json({ message: "Successfully disliked" });
       });
     } catch (err) {

--- a/controllers/articleLikesController.js
+++ b/controllers/articleLikesController.js
@@ -48,7 +48,8 @@ export default class ArticleLikesController {
       });
     } catch (err) {
       res.status(INTERNAL_SERVER_ERROR).json({
-        message: "Unknown error",
+        message:
+          "Sorry, this is not working properly. We now know about this mistake and are working to fix it",
         errors: err.stack
       });
     }
@@ -89,7 +90,8 @@ export default class ArticleLikesController {
       });
     } catch (err) {
       res.status(INTERNAL_SERVER_ERROR).json({
-        message: "Unknown error",
+        message:
+          "Sorry, this is not working properly. We now know about this mistake and are working to fix it",
         errors: err.stack
       });
     }
@@ -128,8 +130,8 @@ export default class ArticleLikesController {
       return res.status(OK).json({ article });
     } catch (err) {
       res.status(INTERNAL_SERVER_ERROR).json({
-        message: "Unknown error",
-        errors: err.stack
+        message:
+          "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
       });
     }
   }

--- a/controllers/articlesController.js
+++ b/controllers/articlesController.js
@@ -15,6 +15,7 @@ const {
   INTERNAL_SERVER_ERROR,
   BAD_REQUEST
 } = constants.statusCode;
+const { SERVER_ERROR } = constants.errorMessage;
 
 const articleQuery = {
   order: [["createdAt", "DESC"]],
@@ -114,9 +115,7 @@ export default class ArticleController {
     } catch (error) {
       return error.details
         ? res.status(BAD_REQUEST).json({ message: error.details[0].message })
-        : res.status(INTERNAL_SERVER_ERROR).json({
-            message: "Can't create the article, server error"
-          });
+        : res.status(INTERNAL_SERVER_ERROR).json({ message: SERVER_ERROR });
     }
   }
 
@@ -146,10 +145,7 @@ export default class ArticleController {
             message: `No article matching with the ${slug} slug`
           });
     } catch (error) {
-      return res.status(INTERNAL_SERVER_ERROR).json({
-        message:
-          "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
-      });
+      return res.status(INTERNAL_SERVER_ERROR).json({ message: SERVER_ERROR });
     }
   }
 
@@ -181,9 +177,7 @@ export default class ArticleController {
           "No more articles found, you can also share your thoughts by creating an article"
       });
     } catch (error) {
-      return res.status(INTERNAL_SERVER_ERROR).json({
-        message: "Can't get the articles, server error"
-      });
+      return res.status(INTERNAL_SERVER_ERROR).json({ message: SERVER_ERROR });
     }
   }
 
@@ -237,9 +231,7 @@ export default class ArticleController {
     } catch (error) {
       return error.details
         ? res.status(BAD_REQUEST).json({ message: error.details[0].message })
-        : res.status(INTERNAL_SERVER_ERROR).json({
-            message: "Can't update the article, server error"
-          });
+        : res.status(INTERNAL_SERVER_ERROR).json({ message: SERVER_ERROR });
     }
   }
 
@@ -269,9 +261,7 @@ export default class ArticleController {
       await Article.destroy({ where: { id: article.id } });
       return res.status(OK).json({ message: "Deleted successfully" });
     } catch (error) {
-      return res.status(INTERNAL_SERVER_ERROR).json({
-        message: "Can't delete the article, server error"
-      });
+      return res.status(INTERNAL_SERVER_ERROR).json({ message: SERVER_ERROR });
     }
   }
 }

--- a/controllers/articlesController.js
+++ b/controllers/articlesController.js
@@ -223,6 +223,7 @@ export default class ArticleController {
       await Article.destroy({ where: { id: article.id } });
       return res.status(OK).json({ message: "Deleted successfully" });
     } catch (error) {
+      console.log("================================", error.stack);
       return res.status(INTERNAL_SERVER_ERROR).json({
         message: "Can't delete the article, server error"
       });

--- a/controllers/articlesController.js
+++ b/controllers/articlesController.js
@@ -372,13 +372,14 @@ export default class ArticleController {
           returning: true,
           limit: 1
         });
+        const tags = await updated
+          .getTagsList({ attributes: ["name"] })
+          .map(t => t.name || null);
         return res.status(CREATED).json({
           article: {
             ...updated.get(),
             author: _.pick(await updated.getAuthor(), ["username", "bio", "image"]),
-            tagsList: await updated.getTagsList({ attributes: ["name"] }).map(t => {
-              return t.name || null;
-            })
+            tagsList: tags
           },
           message: `Updated successfully`
         });

--- a/controllers/articlesController.js
+++ b/controllers/articlesController.js
@@ -55,9 +55,9 @@ export default class ArticleController {
     } catch (error) {
       return error.details
         ? res.status(BAD_REQUEST).json({ message: error.details[0].message })
-        : res
-            .status(INTERNAL_SERVER_ERROR)
-            .json({ message: "Can't create the article, server error" });
+        : res.status(INTERNAL_SERVER_ERROR).json({
+            message: "Can't create the article, server error"
+          });
     }
   }
 
@@ -86,27 +86,25 @@ export default class ArticleController {
         if (bookmarked) {
           return res.status(CREATED).json({
             message: "Article bookmarked",
-            bookmark: bookmarked.dataValues,
-            status: CREATED
+            bookmark: bookmarked.dataValues
           });
         }
-        return res.status(OK).json({
-          message: "Error while bookmarking the article",
-          status: INTERNAL_SERVER_ERROR
+        return res.status(INTERNAL_SERVER_ERROR).json({
+          message: "Error while bookmarking the article"
         });
       }
       const { id } = bookmark.dataValues;
       const deleted = Bookmark.destroy({ where: { id } });
       return deleted
-        ? res.status(OK).json({ message: "Bookmark deleted", status: OK })
+        ? res.status(OK).json({ message: "Bookmark deleted" })
         : res.status(INTERNAL_SERVER_ERROR).json({
-            message: "Error while discarding the bookmark",
-            status: INTERNAL_SERVER_ERROR
+            message: "Error while discarding the bookmark"
           });
     } catch (error) {
-      return res
-        .status(INTERNAL_SERVER_ERROR)
-        .send({ message: error, status: INTERNAL_SERVER_ERROR });
+      return res.status(INTERNAL_SERVER_ERROR).json({
+        message:
+          "Sorry, something went wrong. We already know about this and our developer are working hard to fix it"
+      });
     }
   }
 
@@ -125,9 +123,9 @@ export default class ArticleController {
         article
       });
     } catch (error) {
-      return res
-        .status(500)
-        .json({ message: "Article was NOT posted, Server error" });
+      return res.status(500).json({
+        message: "Article was NOT posted, Server error"
+      });
     }
   }
   /**
@@ -155,9 +153,9 @@ export default class ArticleController {
         message: "Article ready to be posted on Email"
       });
     } catch (error) {
-      return res
-        .status(500)
-        .json({ message: "Article was NOT posted, Server error" });
+      return res.status(500).json({
+        message: "Article was NOT posted, Server error"
+      });
     }
   }
 
@@ -243,9 +241,9 @@ export default class ArticleController {
         message: "Article ready to be posted on linkedIn"
       });
     } catch (error) {
-      return res
-        .status(500)
-        .json({ message: "Article was NOT posted, Server error" });
+      return res.status(500).json({
+        message: "Article was NOT posted, Server error"
+      });
     }
   }
   /**
@@ -331,7 +329,8 @@ export default class ArticleController {
           .json({ message: "Successful", articles, articlesCount });
       }
       return res.status(NOT_FOUND).json({
-        message: "No more articles found, still need to read more?"
+        message:
+          "No more articles found, you can also share your thoughts by creating an article"
       });
     } catch (error) {
       return res
@@ -408,7 +407,12 @@ export default class ArticleController {
       const { slug } = req.params;
       const { user: { id: userId } = {} } = req;
       const article = await Article.findOne({ where: { slug } });
-      if (article.userId !== userId || !article) {
+      if (!article) {
+        return res.status(NOT_FOUND).json({
+          message: `Error deleting, article not found`
+        });
+      }
+      if (article.userId !== userId) {
         return res.status(UNAUTHORIZED).json({
           message: `You can only delete the article you authored`
         });

--- a/controllers/articlesController.js
+++ b/controllers/articlesController.js
@@ -260,8 +260,6 @@ export default class ArticleController {
     try {
       const { slug } = req.params;
       const { id: userId } = req.user;
-      console.log("===================", req.user);
-
       const { description } = req.body;
 
       if (!description) {
@@ -280,7 +278,6 @@ export default class ArticleController {
         article
       });
     } catch (error) {
-      console.log("================================", error.stack);
       return res.status(INTERNAL_SERVER_ERROR).json({
         message:
           "Sorry, this is not working properly. We now know about this mistake and are working to fix it"

--- a/controllers/articlesController.js
+++ b/controllers/articlesController.js
@@ -1,32 +1,37 @@
+import opn from "opn";
+import _ from "lodash";
 import models from "../models";
 import constants from "../helpers/constants";
-import articleValidator from "../helpers/validators/articleValidators";
+import articleValidator, {
+  articleSchema
+} from "../helpers/validators/articleValidators";
 import calculateReadTime from "../helpers/calculateReadTime";
 
-const { User, Article, Tag, ArticleTag } = models;
+const { User, Article, Tag, ArticleTags, Bookmark, ReportArticle } = models;
 const {
   CREATED,
+  OK,
+  NO_CONTENT,
+  UNAUTHORIZED,
   NOT_FOUND,
   INTERNAL_SERVER_ERROR,
-  BAD_REQUEST,
-  OK
+  BAD_REQUEST
 } = constants.statusCode;
 /**
- * @class PostController
+ * @class ArticleController
  */
-export default class PostController {
+export default class ArticleController {
   /**
    * @description This helps the authorized user to create a new article
    * @param  {object} req - The request object
    * @param  {object} res - The response object
-   * @return {object} - It returns the request response object
+   * @returns {object} It returns the request's response object
    */
 
   static async create(req, res) {
     try {
       const { tagsList = [], ...rest } = req.body;
       const { id: userId } = req.user;
-      const refs = [];
       const valid = await articleValidator(req.body);
       const readTime = calculateReadTime(req);
       const user = await User.findOne({ where: { id: userId } });
@@ -37,60 +42,421 @@ export default class PostController {
           slug: "",
           userId
         });
-        const { id: articleId } = article.dataValues;
-        await tagsList.map(async tag => {
-          const tags = await Tag.findOrCreate({ where: { name: tag } });
-          refs.push(
-            await ArticleTag.create({
-              articleId,
-              tagId: tags[0].dataValues.id
-            })
+        tagsList.map(async t => {
+          const tag = await Tag.findOrCreate({ where: { name: t } }).spread(
+            tg => tg
           );
+          await article.addTagsList(tag);
         });
-        return refs
-          ? res.status(CREATED).json({
-              status: CREATED,
-              message: "Article created",
-              article: { ...article.dataValues, tagsList }
-            })
-          : res
-              .status(NOT_FOUND)
-              .json({ status: NOT_FOUND, message: "Please consider logging in" });
+        res.status(CREATED).json({
+          message: "Article created",
+          article: { ...article.get(), tagsList }
+        });
       }
     } catch (error) {
-      if (error.details) {
-        return res
-          .status(BAD_REQUEST)
-          .send({ message: error.details[0].message, status: BAD_REQUEST });
-      }
-      return res.status(INTERNAL_SERVER_ERROR).send({
-        message:
-          "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
-      });
+      return error.details
+        ? res.status(BAD_REQUEST).json({ message: error.details[0].message })
+        : res
+            .status(INTERNAL_SERVER_ERROR)
+            .json({ message: "Can't create the article, server error" });
     }
   }
 
   /**
-   *
-   * FindOneArticle.
-   *
+   * @description It helps the user to bookmark the article for reading it later.
+   * @param  {object} req - The request object
+   * @param  {object} res - The response object
+   * @returns {object} It returns the request's response object
+   */
+
+  static async bookmark(req, res) {
+    try {
+      const { id: userId } = req.user;
+      const { slug } = req.params;
+      const user = await User.findOne({ where: { id: userId } });
+      const article = await Article.findOne({ where: { slug } });
+      if (!article || !user) {
+        return res.status(NOT_FOUND).json({
+          message: `The article with this slug ${slug} doesn't exist`
+        });
+      }
+      const { id: articleId } = article.dataValues;
+      const bookmark = await Bookmark.findOne({ where: { userId, articleId } });
+      if (!bookmark) {
+        const bookmarked = await Bookmark.create({ userId, articleId });
+        if (bookmarked) {
+          return res.status(CREATED).json({
+            message: "Article bookmarked",
+            bookmark: bookmarked.dataValues,
+            status: CREATED
+          });
+        }
+        return res.status(OK).json({
+          message: "Error while bookmarking the article",
+          status: INTERNAL_SERVER_ERROR
+        });
+      }
+      const { id } = bookmark.dataValues;
+      const deleted = Bookmark.destroy({ where: { id } });
+      return deleted
+        ? res.status(OK).json({ message: "Bookmark deleted", status: OK })
+        : res.status(INTERNAL_SERVER_ERROR).json({
+            message: "Error while discarding the bookmark",
+            status: INTERNAL_SERVER_ERROR
+          });
+    } catch (error) {
+      return res
+        .status(INTERNAL_SERVER_ERROR)
+        .send({ message: error, status: INTERNAL_SERVER_ERROR });
+    }
+  }
+
+  /**
+   * @description It helps the user to fetch a single article.
    * @param  {Object} req - The request object.
    * @param  {Object} res - The response object.
-   * @return {Object} - It returns the response object.
+   * @returns {object} It returns the response object.
    */
 
   static async findOneArticle(req, res) {
     try {
       const { slug } = req.params;
       const article = await Article.findOne({ where: { slug } });
+      return res.status(200).json({
+        article
+      });
+    } catch (error) {
+      return res
+        .status(500)
+        .json({ message: "Article was NOT posted, Server error" });
+    }
+  }
+  /**
+   * @description It helps the user to share the article via email.
+   * @param  {object} req - The request object.
+   * @param  {object} res - The response object.
+   * @returns {object} It returns the response object.
+   */
+
+  static async shareOnEmail(req, res) {
+    try {
+      const { slug } = req.params;
+      const article = await Article.findOne({ where: { slug } });
+      if (!article) {
+        return res.status(400).json({
+          message: "Article doesn't exist"
+        });
+      }
+      opn(
+        `mailto:?subject=${article.dataValues.title}&body=${
+          process.env.SERVER_HOST
+        }/article/${slug}`
+      );
+      return res.status(200).json({
+        message: "Article ready to be posted on Email"
+      });
+    } catch (error) {
+      return res
+        .status(500)
+        .json({ message: "Article was NOT posted, Server error" });
+    }
+  }
+
+  /**
+   * @description It helps the user to share the article via Facebook.
+   * @param  {Object} req - The request object.
+   * @param  {Object} res - The response object.
+   * @returns {object} It returns the response object.
+   */
+
+  static async shareOnFacebook(req, res) {
+    try {
+      const { slug } = req.params;
+      if (process.env === "production") {
+        opn(
+          `https://www.facebook.com/sharer/sharer.php?&u=${
+            process.env.SERVER_HOST
+          }/article/${slug}`
+        );
+      } else {
+        opn(
+          `https://www.facebook.com/sharer/sharer.php?&u=http://tolocalhost.com/api/v1/article/${slug}`
+        );
+      }
+
+      return res.status(200).json({
+        message: "Article ready to be posted on facebook"
+      });
+    } catch (error) {
+      return res
+        .status(500)
+        .json({ message: "Article was NOT posted, Server error" });
+    }
+  }
+
+  /**
+   * @description It helps the user to share the article via Twitter.
+   * @param  {Object} req - The request object.
+   * @param  {Object} res - The response object.
+   * @returns {object} It returns the response object.
+   */
+
+  static async shareOnTwitter(req, res) {
+    try {
+      const { slug } = req.params;
+      opn(
+        `https://twitter.com/intent/tweet?text=${
+          process.env.SERVER_HOST
+        }/article/${slug}`
+      );
+      return res.status(200).json({
+        message: "Article ready to be posted on twitter"
+      });
+    } catch (error) {
+      return res
+        .status(500)
+        .json({ message: "Article was NOT posted, Server error" });
+    }
+  }
+
+  /**
+   * @description It helps the user to share the article via LinkedIn.
+   * @param  {Object} req - The request object.
+   * @param  {Object} res - The response object.
+   * @returns {object} It returns the response object.
+   */
+
+  static async shareOnLinkedin(req, res) {
+    try {
+      const { slug } = req.params;
+      if (process.env === "production") {
+        opn(
+          `https://www.linkedin.com/sharing/share-offsite/?url=${
+            process.env.SERVER_HOST
+          }/article/${slug}`
+        );
+      } else {
+        opn(
+          `https://www.linkedin.com/sharing/share-offsite/?url=http://tolocalhost.com/api/v1/article/${slug}`
+        );
+      }
+      return res.status(200).json({
+        message: "Article ready to be posted on linkedIn"
+      });
+    } catch (error) {
+      return res
+        .status(500)
+        .json({ message: "Article was NOT posted, Server error" });
+    }
+  }
+  /**
+   * @description This creates report an article.
+   * @param  {Object} req - The request object.
+   * @param  {Object} res - The response object.
+   * @returns {Object} - It returns the request response object.
+   */
+
+  static async reportArticle(req, res) {
+    try {
+      const { slug } = req.params;
+      const { id: userId } = req.user;
+      console.log("===================", req.user);
+
+      const { description } = req.body;
+
+      if (!description) {
+        return res.status(BAD_REQUEST).json({ message: "Please, give a reason" });
+      }
+      const article = await Article.findOne({
+        where: { slug }
+      });
+      const { articleId } = article.dataValues;
+      const reportArticle = await ReportArticle.create({
+        articleId,
+        userId,
+        description
+      });
       return res.status(OK).json({
         article
       });
     } catch (error) {
+      console.log("================================", error.stack);
       return res.status(INTERNAL_SERVER_ERROR).json({
         message:
           "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
       });
+    }
+  }
+  /**
+   * @description It helps the user to fetch all of the created articles.
+   * @param  {object} req - The request object
+   * @param  {object} res - The response object
+   * @returns {object} It returns the request's response object
+   */
+
+  static async findAll(req, res) {
+    const {
+      query: {
+        author = null,
+        favorited: liked = null,
+        tag: oneTag = null,
+        page = 1,
+        limit = 20
+      },
+      user: { id = null } = {}
+    } = req;
+    try {
+      const all = await Article.findAll({
+        offset: (Number(page) - 1) * Number(limit),
+        limit,
+        order: [["createdAt", "DESC"]],
+        include: [
+          {
+            model: User,
+            as: "author",
+            attributes: ["username", "bio", "image"],
+            where: author ? { username: author } : {},
+            include: [
+              {
+                model: User,
+                as: "followers",
+                attributes: ["id", "username"]
+              }
+            ]
+          },
+          {
+            model: User,
+            as: "likes",
+            attributes: ["username"],
+            through: { attributes: [] }
+          },
+          {
+            model: Tag,
+            attributes: ["name"],
+            as: "tagsList",
+            through: { attributes: [] }
+          }
+        ]
+      });
+      if (all.length) {
+        const articles = all
+          .map(each => {
+            const {
+              author: { followers, username, bio, image },
+              tagsList,
+              likes,
+              ...article
+            } = each.get();
+            const following = !!_.dropWhile(followers, f => f.id !== id).length;
+            return {
+              ...article,
+              likes: likes.map(like => like.username),
+              author: { following, username, bio, image },
+              favorited: !!likes.length,
+              favoritesCount: likes.length,
+              tagsList: tagsList.map(tag => tag.get().name || null)
+            };
+          })
+          .filter(art => liked === null || art.likes.includes(liked))
+          .filter(art => oneTag === null || art.tagsList.includes(oneTag));
+        return res.status(OK).json({
+          message: "Successful",
+          articles,
+          articlesCount: articles.length
+        });
+      }
+      return res.status(NO_CONTENT).json({ message: "No articles created yet!" });
+    } catch (error) {
+      return res
+        .status(INTERNAL_SERVER_ERROR)
+        .json({ message: "Can't get the articles, server error" });
+    }
+  }
+
+  /**
+   * @description It helps the user to update any of his articles.
+   * @param  {object} req - The request object
+   * @param  {object} res - The response object
+   * @returns {object} It returns the request's response object
+   */
+
+  static async update(req, res) {
+    try {
+      const {
+        params: { slug },
+        user: { id: userId },
+        body
+      } = req;
+      const article = await Article.findOne({ where: { slug, userId } });
+      if (article) {
+        const allowed = _.pick(body, Object.keys(articleSchema));
+        const valid = await articleValidator(
+          allowed,
+          _.pick(articleSchema, Object.keys(allowed))
+        );
+        const { tagsList = [], ...rest } = valid;
+        if (tagsList.length) {
+          tagsList.map(async t => {
+            const tag = await Tag.findOrCreate({ where: { name: t } }).spread(
+              tg => tg
+            );
+            await article.addTagsList(tag);
+          });
+        }
+        const updated = await article.update(rest, {
+          where: { id: article.id, userId },
+          returning: true,
+          limit: 1
+        });
+        return res.status(CREATED).json({
+          article: {
+            ...updated.get(),
+            author: _.pick(await updated.getAuthor(), ["username", "bio", "image"]),
+            tagsList: await updated.getTagsList({ attributes: ["name"] }).map(t => {
+              return t.name || null;
+            })
+          },
+          message: `Updated successfully`
+        });
+      }
+      return res.status(UNAUTHORIZED).json({
+        message: `You can only update the article you authored`
+      });
+    } catch (error) {
+      return error.details
+        ? res.status(BAD_REQUEST).json({ message: error.details[0].message })
+        : res
+            .status(INTERNAL_SERVER_ERROR)
+            .json({ message: "Can't update the article, server error" });
+    }
+  }
+
+  /**
+   * @description It helps the user to delete any of his articles.
+   * @param  {object} req - The request object
+   * @param  {object} res - The response object
+   * @returns {object} It returns the request's response object
+   */
+
+  static async delete(req, res) {
+    try {
+      const {
+        params: { slug },
+        user: { id: userId }
+      } = req;
+      const article = await Article.findOne({ where: { slug } });
+      if (article.userId !== userId || !article) {
+        return res
+          .status(UNAUTHORIZED)
+          .json({ message: `You can only delete the article you authored` });
+      }
+      await ArticleTags.destroy({ where: { articleId: article.id } });
+      await Article.destroy({ where: { id: article.id } });
+      return res.status(OK).json({ message: "Deleted successfully" });
+    } catch (error) {
+      return res
+        .status(INTERNAL_SERVER_ERROR)
+        .json({ message: "Can't delete the article, server error" });
     }
   }
 }

--- a/controllers/articlesController.js
+++ b/controllers/articlesController.js
@@ -98,6 +98,8 @@ export default class ArticleController {
         offset: (Number(page) - 1) * Number(limit),
         limit,
         order: [["createdAt", "DESC"]],
+        where: { deletedAt: null },
+        attributes: { exclude: ["deletedAt"] },
         include: [
           {
             model: User,
@@ -137,9 +139,9 @@ export default class ArticleController {
           "No more articles found, you can also share your thoughts by creating an article"
       });
     } catch (error) {
-      return res
-        .status(INTERNAL_SERVER_ERROR)
-        .json({ message: "Can't get the articles, server error" });
+      return res.status(INTERNAL_SERVER_ERROR).json({
+        message: "Can't get the articles, server error"
+      });
     }
   }
 
@@ -225,7 +227,6 @@ export default class ArticleController {
       await Article.destroy({ where: { id: article.id } });
       return res.status(OK).json({ message: "Deleted successfully" });
     } catch (error) {
-      console.log("================================", error.stack);
       return res.status(INTERNAL_SERVER_ERROR).json({
         message: "Can't delete the article, server error"
       });

--- a/controllers/articlesController.js
+++ b/controllers/articlesController.js
@@ -92,9 +92,11 @@ export default class ArticleController {
 
   static async findAll(req, res) {
     const { user: { id = null } = {} } = req;
-
+    const { page = 1, limit = 20 } = req.query;
     try {
       const all = await Article.findAll({
+        offset: (Number(page) - 1) * Number(limit),
+        limit,
         order: [["createdAt", "DESC"]],
         include: [
           {

--- a/controllers/bookmarkController.js
+++ b/controllers/bookmarkController.js
@@ -4,6 +4,7 @@ import constants from "../helpers/constants";
 const { User, Article, Bookmark } = models;
 
 const { CREATED, NOT_FOUND, INTERNAL_SERVER_ERROR, OK } = constants.statusCode;
+const { SERVER_ERROR } = constants.errorMessage;
 export default class BookMarkController {
   /**
    * @description It helps the user to bookmark the article for reading it later.
@@ -33,9 +34,7 @@ export default class BookMarkController {
             bookmark: bookmarked.dataValues
           });
         }
-        return res.status(INTERNAL_SERVER_ERROR).json({
-          message: "Error while bookmarking the article"
-        });
+        return res.status(INTERNAL_SERVER_ERROR).json({ message: SERVER_ERROR });
       }
       const { id } = bookmark.dataValues;
       const deleted = Bookmark.destroy({ where: { id } });
@@ -45,10 +44,7 @@ export default class BookMarkController {
             message: "Error while discarding the bookmark"
           });
     } catch (error) {
-      return res.status(INTERNAL_SERVER_ERROR).json({
-        message:
-          "Sorry, something went wrong. We already know about this and our developer are working hard to fix it"
-      });
+      return res.status(INTERNAL_SERVER_ERROR).json({ message: SERVER_ERROR });
     }
   }
 }

--- a/controllers/bookmarkController.js
+++ b/controllers/bookmarkController.js
@@ -3,13 +3,13 @@ import constants from "../helpers/constants";
 
 const { User, Article, Bookmark } = models;
 
-const { CREATED, NOT_FOUND, INTERNAL_SERVER_ERROR, GONE } = constants.statusCode;
+const { CREATED, NOT_FOUND, INTERNAL_SERVER_ERROR, OK } = constants.statusCode;
 export default class BookMarkController {
   /**
    * @description It helps the user to bookmark the article for reading it later.
    * @param  {object} req - The request object
    * @param  {object} res - The response object
-   * @return {object} - It returns the request response object
+   * @returns {object} It returns the request's response object
    */
 
   static async bookmark(req, res) {
@@ -20,7 +20,6 @@ export default class BookMarkController {
       const article = await Article.findOne({ where: { slug } });
       if (!article || !user) {
         return res.status(NOT_FOUND).json({
-          status: NOT_FOUND,
           message: `The article with this slug ${slug} doesn't exist`
         });
       }
@@ -31,27 +30,24 @@ export default class BookMarkController {
         if (bookmarked) {
           return res.status(CREATED).json({
             message: "Article bookmarked",
-            bookmark: bookmarked.dataValues,
-            status: CREATED
+            bookmark: bookmarked.dataValues
           });
         }
-        return res.status(GONE).json({
-          message: "Error while bookmarking the article",
-          status: GONE
+        return res.status(INTERNAL_SERVER_ERROR).json({
+          message: "Error while bookmarking the article"
         });
       }
       const { id } = bookmark.dataValues;
       const deleted = Bookmark.destroy({ where: { id } });
       return deleted
-        ? res.status(GONE).json({ message: "Bookmark deleted", status: GONE })
-        : res.status(GONE).json({
-            message: "Error while discarding the bookmark",
-            status: GONE
+        ? res.status(OK).json({ message: "Bookmark deleted" })
+        : res.status(INTERNAL_SERVER_ERROR).json({
+            message: "Error while discarding the bookmark"
           });
     } catch (error) {
-      return res.status(INTERNAL_SERVER_ERROR).send({
+      return res.status(INTERNAL_SERVER_ERROR).json({
         message:
-          "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
+          "Sorry, something went wrong. We already know about this and our developer are working hard to fix it"
       });
     }
   }

--- a/controllers/commentController.js
+++ b/controllers/commentController.js
@@ -106,7 +106,7 @@ export default class CommentController {
         { where: { id: commentId } }
       );
       res.status(CREATED).json({
-        message: "Comment unliked",
+        message: "Comment Disliked",
         unlikeComment,
         updatedComment: updateCommentLikes[0][0]
       });

--- a/controllers/followersController.js
+++ b/controllers/followersController.js
@@ -1,7 +1,13 @@
 import models from "../models";
 import constants from "../helpers/constants";
 
-const { CREATED, INTERNAL_SERVER_ERROR, NOT_FOUND, ACCEPTED, CONFLICT } = constants.statusCode;
+const {
+  CREATED,
+  INTERNAL_SERVER_ERROR,
+  NOT_FOUND,
+  ACCEPTED,
+  CONFLICT
+} = constants.statusCode;
 const { User, Follower } = models;
 
 /**
@@ -43,9 +49,9 @@ export default class FollowerController {
           .json({ message: "You are already following this author" });
       });
     } catch (error) {
-      res.status(INTERNAL_SERVER_ERROR).json({
+      res.status(500).json({
         message: "Following user failed",
-        errors: "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
+        errors: "Something happened, please try again"
       });
     }
   }
@@ -84,9 +90,9 @@ export default class FollowerController {
         .status(ACCEPTED)
         .json({ message: "You have unfollowed this author" });
     } catch (error) {
-      res.status(INTERNAL_SERVER_ERROR).json({
+      res.status(500).json({
         message: "Unfollowing user failed",
-        errors: "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
+        errors: "Something happened, please try again"
       });
     }
   }
@@ -116,15 +122,16 @@ export default class FollowerController {
         include: [
           {
             model: User,
+            as: "followings",
             attributes: ["id", "username", "firstname", "lastname", "image", "bio"]
           }
         ]
       });
       res.json({ followers });
     } catch (error) {
-      res.status(INTERNAL_SERVER_ERROR).json({
+      res.status(500).json({
         message: "Unknown error occurred",
-        errors: "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
+        errors: "Something happened, please try again"
       });
     }
   }
@@ -157,9 +164,9 @@ export default class FollowerController {
       }
       res.json({ user });
     } catch (error) {
-      res.status(INTERNAL_SERVER_ERROR).json({
+      res.status(500).json({
         message: "Unknown error occurred",
-        errors: "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
+        errors: "Something happened, please try again"
       });
     }
   }

--- a/controllers/followersController.js
+++ b/controllers/followersController.js
@@ -1,13 +1,7 @@
 import models from "../models";
 import constants from "../helpers/constants";
 
-const {
-  CREATED,
-  INTERNAL_SERVER_ERROR,
-  NOT_FOUND,
-  ACCEPTED,
-  CONFLICT
-} = constants.statusCode;
+const { CREATED, NOT_FOUND, ACCEPTED, CONFLICT } = constants.statusCode;
 const { User, Follower } = models;
 
 /**

--- a/controllers/followersController.js
+++ b/controllers/followersController.js
@@ -1,8 +1,15 @@
 import models from "../models";
 import constants from "../helpers/constants";
 
-const { CREATED, NOT_FOUND, ACCEPTED, CONFLICT } = constants.statusCode;
+const {
+  CREATED,
+  NOT_FOUND,
+  ACCEPTED,
+  CONFLICT,
+  INTERNAL_SERVER_ERROR
+} = constants.statusCode;
 const { User, Follower } = models;
+const { SERVER_ERROR } = constants.errorMessage;
 
 /**
  *@class FollowerController
@@ -43,9 +50,8 @@ export default class FollowerController {
           .json({ message: "You are already following this author" });
       });
     } catch (error) {
-      res.status(500).json({
-        message: "Following user failed",
-        errors: "Something happened, please try again"
+      res.status().json({
+        message: SERVER_ERROR
       });
     }
   }
@@ -84,10 +90,7 @@ export default class FollowerController {
         .status(ACCEPTED)
         .json({ message: "You have unfollowed this author" });
     } catch (error) {
-      res.status(500).json({
-        message: "Unfollowing user failed",
-        errors: "Something happened, please try again"
-      });
+      res.status(INTERNAL_SERVER_ERROR).json({ message: SERVER_ERROR });
     }
   }
 
@@ -123,10 +126,7 @@ export default class FollowerController {
       });
       res.json({ followers });
     } catch (error) {
-      res.status(500).json({
-        message: "Unknown error occurred",
-        errors: "Something happened, please try again"
-      });
+      res.status(INTERNAL_SERVER_ERROR).json({ message: SERVER_ERROR });
     }
   }
 
@@ -158,10 +158,7 @@ export default class FollowerController {
       }
       res.json({ user });
     } catch (error) {
-      res.status(500).json({
-        message: "Unknown error occurred",
-        errors: "Something happened, please try again"
-      });
+      res.status(INTERNAL_SERVER_ERROR).json({ message: SERVER_ERROR });
     }
   }
 }

--- a/controllers/reportArticleController.js
+++ b/controllers/reportArticleController.js
@@ -3,7 +3,7 @@ import constants from "../helpers/constants";
 
 const { Article, ReportArticle } = models;
 
-const { INTERNAL_SERVER_ERROR, BAD_REQUEST, OK, CONFLICT } = constants.statusCode;
+const { INTERNAL_SERVER_ERROR, BAD_REQUEST, OK } = constants.statusCode;
 
 export default class ReportArticleController {
   /**
@@ -21,9 +21,7 @@ export default class ReportArticleController {
       if (!description) {
         return res.status(BAD_REQUEST).json({ message: "Please, give a reason" });
       }
-      const article = await Article.findOne({
-        where: { slug }
-      });
+      const article = await Article.findOne({ where: { slug } });
       const { id: articleId } = article.dataValues;
       const reportArticle = await ReportArticle.create({
         articleId,
@@ -36,7 +34,7 @@ export default class ReportArticleController {
       });
     } catch (error) {
       if (error.name === "SequelizeUniqueConstraintError") {
-        return res.status(CONFLICT).json({
+        return res.status(OK).json({
           message: "Article already reported"
         });
       }

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -62,5 +62,9 @@ export default {
     LOOP_DETECTED: 508,
     NOT_EXTENDED: 510,
     NET_AUTH_REQUIRED: 511
+  },
+  errorMessage: {
+    SERVER_ERROR:
+      "Sorry, this is not working properly. We already know about this our team is working hard to fix it"
   }
 };

--- a/helpers/resetPasswordTemplate.js
+++ b/helpers/resetPasswordTemplate.js
@@ -1,9 +1,9 @@
 import dotenv from "dotenv";
-import { template } from "handlebars";
+
 dotenv.config();
 
 const resetPasswordTemplate = token => {
-  const template = `
+  return `
     <html>
         <head>
             <title></title>
@@ -50,7 +50,6 @@ const resetPasswordTemplate = token => {
     </html>
 
   `;
-  return template;
 };
 
 export default resetPasswordTemplate;

--- a/helpers/validators/articleValidators.js
+++ b/helpers/validators/articleValidators.js
@@ -1,8 +1,9 @@
 import Joi from "joi";
 
-const articleSchema = {
+export const articleSchema = {
   title: Joi.string()
     .trim()
+    .min(10)
     .required(),
   description: Joi.string()
     .trim()
@@ -11,7 +12,8 @@ const articleSchema = {
     .required(),
   body: Joi.string()
     .trim()
+    // .min(100)
     .required(),
   tagsList: Joi.array()
 };
-export default article => Joi.validate(article, articleSchema);
+export default (article, schema = articleSchema) => Joi.validate(article, schema);

--- a/helpers/validators/articleValidators.js
+++ b/helpers/validators/articleValidators.js
@@ -12,7 +12,6 @@ export const articleSchema = {
     .required(),
   body: Joi.string()
     .trim()
-    // .min(100)
     .required(),
   tagsList: Joi.array()
 };

--- a/helpers/validators/articleValidators.js
+++ b/helpers/validators/articleValidators.js
@@ -12,6 +12,7 @@ export const articleSchema = {
     .required(),
   body: Joi.string()
     .trim()
+    // .min(100)
     .required(),
   tagsList: Joi.array()
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 import express from "express";
-import bodyParser from "body-parser";
 import session from "express-session";
 import cors from "cors";
 import errorhandler from "errorhandler";
@@ -26,10 +25,6 @@ app.use(express.urlencoded({ extended: false }));
 app.use(morgan("dev"));
 app.use(methodOverride());
 
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
-app.use(morgan("dev"));
-
 app.use(express.static(`${__dirname}/public`));
 app.use(passport.initialize());
 passportConfig(passport);
@@ -43,9 +38,7 @@ app.use(
   })
 );
 
-if (!isProduction) {
-  app.use(errorhandler());
-}
+if (!isProduction) app.use(errorhandler());
 
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 app.use("/api/v1", routers);

--- a/middlewares/optionalAuth.js
+++ b/middlewares/optionalAuth.js
@@ -1,0 +1,8 @@
+import passport from "passport";
+
+export default (req, res, next) => {
+  passport.authenticate("jwt", { session: false }, (err, user) => {
+    if (user) req.user = user.dataValues;
+    next();
+  })(req, res, next);
+};

--- a/middlewares/passport.js
+++ b/middlewares/passport.js
@@ -1,38 +1,25 @@
-import dotenv from "dotenv";
 import passportJwt from "passport-jwt";
 import models from "../models";
 
-dotenv.config();
-const { Strategy, ExtractJwt } = passportJwt;
+const JwtStrategy = passportJwt.Strategy;
+const { ExtractJwt } = passportJwt;
+
 const { User } = models;
-const options = {
-  jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-  secretOrKey: process.env.SECRET_KEY
-};
-
-/**
- * @description - The middleware to check for authentication.
- * @param  {object} req - The request object
- * @param  {object} res - The response object
- * @param  {function} next - The next handler function in the request pipeline
- */
-
 export default passport => {
   passport.use(
-    new Strategy(options, async (jwtPayload, done) => {
-      try {
-        const user = await User.findOne({
-          where: {
-            id: jwtPayload.id
-          },
-          attributes: ["id", "username", "email"]
-        });
-        return user ? done(null, user) : done(null, false);
-      } catch (error) {
-        return done(error, false, {
-          message: "Please provide a token to perform this action"
-        });
+    new JwtStrategy(
+      {
+        jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+        secretOrKey: process.env.SECRET_KEY
+      },
+      async (jwtPayload, done) => {
+        try {
+          const user = await User.findOne({ where: { id: jwtPayload.id } });
+          done(null, user || false);
+        } catch (error) {
+          done(error);
+        }
       }
-    })
+    )
   );
 };

--- a/migrations/20190211111550-create-article.js
+++ b/migrations/20190211111550-create-article.js
@@ -1,30 +1,29 @@
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable("articles", {
-      id: {
-        allowNull: false,
-        unique: true,
-        primaryKey: true,
-        type: Sequelize.UUID,
-        defaultValue: Sequelize.UUIDV4
+    return queryInterface.createTable(
+      "articles",
+      {
+        id: {
+          allowNull: false,
+          unique: true,
+          primaryKey: true,
+          type: Sequelize.UUID,
+          defaultValue: Sequelize.UUIDV4
+        },
+        title: { type: Sequelize.STRING, allowNull: false },
+        description: { type: Sequelize.TEXT, allowNull: false },
+        body: { type: Sequelize.TEXT, allowNull: false },
+        userId: {
+          allowNull: false,
+          type: Sequelize.UUID,
+          references: { model: "users", key: "id" }
+        },
+        createdAt: { allowNull: false, type: Sequelize.DATE },
+        updatedAt: { allowNull: false, type: Sequelize.DATE },
+        deletedAt: { type: Sequelize.DATE }
       },
-      title: { type: Sequelize.STRING, allowNull: false },
-      description: { type: Sequelize.TEXT, allowNull: false },
-      body: { type: Sequelize.TEXT, allowNull: false },
-      userId: {
-        allowNull: false,
-        type: Sequelize.UUID,
-        references: { model: "users", key: "id" }
-      },
-      createdAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      },
-      updatedAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      }
-    });
+      { paranoid: true }
+    );
   },
   down: (queryInterface, Sequelize) => {
     return queryInterface.dropTable("articles");

--- a/migrations/20190211111550-create-article.js
+++ b/migrations/20190211111550-create-article.js
@@ -1,29 +1,24 @@
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable(
-      "articles",
-      {
-        id: {
-          allowNull: false,
-          unique: true,
-          primaryKey: true,
-          type: Sequelize.UUID,
-          defaultValue: Sequelize.UUIDV4
-        },
-        title: { type: Sequelize.STRING, allowNull: false },
-        description: { type: Sequelize.TEXT, allowNull: false },
-        body: { type: Sequelize.TEXT, allowNull: false },
-        userId: {
-          allowNull: false,
-          type: Sequelize.UUID,
-          references: { model: "users", key: "id" }
-        },
-        createdAt: { allowNull: false, type: Sequelize.DATE },
-        updatedAt: { allowNull: false, type: Sequelize.DATE },
-        deletedAt: { type: Sequelize.DATE }
+    return queryInterface.createTable("articles", {
+      id: {
+        allowNull: false,
+        unique: true,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4
       },
-      { paranoid: true }
-    );
+      title: { type: Sequelize.STRING, allowNull: false },
+      description: { type: Sequelize.TEXT, allowNull: false },
+      body: { type: Sequelize.TEXT, allowNull: false },
+      userId: {
+        allowNull: false,
+        type: Sequelize.UUID,
+        references: { model: "users", key: "id" }
+      },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE }
+    });
   },
   down: (queryInterface, Sequelize) => {
     return queryInterface.dropTable("articles");

--- a/migrations/20190211200749-create-tag.js
+++ b/migrations/20190211200749-create-tag.js
@@ -1,4 +1,4 @@
-"use strict";
+
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable("tags", {
@@ -10,7 +10,8 @@ module.exports = {
       },
       name: {
         allowNull: false,
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        unique: true
       },
       createdAt: {
         allowNull: false,

--- a/migrations/20190212161435-create-article-tag.js
+++ b/migrations/20190212161435-create-article-tag.js
@@ -1,4 +1,3 @@
-"use strict";
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable("articleTags", {
@@ -27,6 +26,6 @@ module.exports = {
     });
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable("ArticleTags");
+    return queryInterface.dropTable("articleTags");
   }
 };

--- a/migrations/20190320143722-add-deletedat-to-article.js
+++ b/migrations/20190320143722-add-deletedat-to-article.js
@@ -1,0 +1,8 @@
+module.exports = {
+  up: (queryInterface, Sequelize) =>
+    Promise.all([
+      queryInterface.addColumn("articles", "deletedAt", { type: Sequelize.DATE })
+    ]),
+  down: (queryInterface, Sequelize) =>
+    Promise.all([queryInterface.removeColumn("articles", "deletedAt")])
+};

--- a/models/Article.js
+++ b/models/Article.js
@@ -35,14 +35,14 @@ export default (sequelize, DataTypes) => {
   Article.associate = models => {
     Article.belongsTo(models.User, {
       foreignKey: "userId",
+      as: "author",
       onDelete: "CASCADE",
       hooks: true
     });
     Article.belongsToMany(models.Tag, {
-      through: "ArticleTag",
+      through: "ArticleTags",
       foreignKey: "articleId",
-      onDelete: "CASCADE",
-      hooks: true
+      as: "tagsList"
     });
     Article.hasMany(models.Rating, {
       foreignKey: "articleId",
@@ -63,19 +63,10 @@ export default (sequelize, DataTypes) => {
       onDelete: "CASCADE",
       hooks: true
     });
-    Article.hasMany(models.ReportArticle, {
-      foreignKey: "articleId",
-      onDelete: "CASCADE",
-      hooks: true
-    });
-    Article.hasMany(models.ReportArticle, {
-      foreignKey: "articleId",
-      onDelete: "CASCADE",
-      hooks: true
-    });
     Article.belongsToMany(models.User, {
       through: models.ArticleLike,
       as: "likes",
+      onDelete: "CASCADE",
       foreignKey: "articleId"
     });
   };

--- a/models/Article.js
+++ b/models/Article.js
@@ -23,6 +23,7 @@ export default (sequelize, DataTypes) => {
     },
     {
       tableName: "articles",
+      paranoid: true,
       hooks: {
         beforeCreate(article) {
           article.slug = slug(

--- a/models/Article.js
+++ b/models/Article.js
@@ -52,6 +52,7 @@ export default (sequelize, DataTypes) => {
     Article.hasMany(models.Comment, {
       foreignKey: "articleId",
       onDelete: "CASCADE",
+      as: "comments",
       hooks: true
     });
     Article.hasMany(models.Bookmark, {

--- a/models/ArticleTag.js
+++ b/models/ArticleTag.js
@@ -1,16 +1,18 @@
 export default (sequelize, DataTypes) => {
-  const ArticleTag = sequelize.define(
-    "ArticleTag",
+  const ArticleTags = sequelize.define(
+    "ArticleTags",
     {
       id: {
         allowNull: false,
+        unique: true,
         primaryKey: true,
         type: DataTypes.UUID,
         defaultValue: DataTypes.UUIDV4
-      }
+      },
+      tagId: DataTypes.UUID,
+      articleId: DataTypes.UUID
     },
     { tableName: "articleTags" }
   );
-
-  return ArticleTag;
+  return ArticleTags;
 };

--- a/models/Follower.js
+++ b/models/Follower.js
@@ -17,7 +17,8 @@ module.exports = (sequelize, DataTypes) => {
   );
   Follower.associate = models => {
     Follower.belongsTo(models.User, {
-      foreignKey: "followerId"
+      foreignKey: "followerId",
+      as: "followings"
     });
   };
   return Follower;

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -8,14 +8,15 @@ export default (sequelize, DataTypes) => {
         type: DataTypes.UUID,
         defaultValue: DataTypes.UUIDV4
       },
-      name: DataTypes.STRING
+      name: { type: DataTypes.STRING, unique: true, allowNull: false }
     },
     { tableName: "tags" }
   );
   Tag.associate = models => {
     Tag.belongsToMany(models.Article, {
-      through: "ArticleTag",
+      through: "ArticleTags",
       foreignKey: "tagId",
+      as: "articles",
       onDelete: "CASCADE",
       hooks: true
     });

--- a/models/User.js
+++ b/models/User.js
@@ -67,6 +67,7 @@ export default (sequelize, DataTypes) => {
   User.associate = models => {
     User.hasMany(models.Article, {
       foreignKey: "userId",
+      as: "author",
       onDelete: "CASCADE",
       hooks: true
     });
@@ -79,6 +80,7 @@ export default (sequelize, DataTypes) => {
     User.belongsToMany(models.Comment, {
       through: models.CommentLike,
       as: "likedBy",
+      onDelete: "CASCADE",
       foreignKey: "userId"
     });
     User.hasMany(models.Rating, {
@@ -92,23 +94,18 @@ export default (sequelize, DataTypes) => {
       targetKey: "followerId",
       onDelete: "CASCADE"
     });
-
+    User.belongsToMany(models.User, {
+      through: models.Follower,
+      as: "followers",
+      onDelete: "CASCADE",
+      foreignKey: "followingId",
+      targetKey: "followingId"
+    });
     User.belongsToMany(models.Article, {
       through: models.ArticleLike,
       as: "likes",
-      foreignKey: "userId",
       onDelete: "CASCADE",
-      targetKey: "followerId"
-    });
-    User.hasMany(models.ReportArticle, {
-      foreignKey: "userId",
-      onDelete: "CASCADE",
-      hooks: true
-    });
-    User.hasMany(models.ReportArticle, {
-      foreignKey: "userId",
-      onDelete: "CASCADE",
-      hooks: true
+      foreignKey: "userId"
     });
     User.hasMany(models.ReportArticle, {
       foreignKey: "userId",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
     "lodash": "^4.17.11",
     "method-override": "^2.3.10",
     "methods": "^1.1.2",
-    "mongoose": "^5.2.2",
-    "mongoose-unique-validator": "^2.0.1",
     "morgan": "^1.9.0",
     "nock": "^10.0.6",
     "nodemon": "^1.18.9",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Social platform for the creative at heart",
   "main": "index.js",
   "scripts": {
-    "test": " NODE_ENV=test yarn run db:migrate && NODE_ENV=test nyc --reporter=text --reporter=lcov mocha --require babel-polyfill --require @babel/register tests/*  --timeout 10000 --exit",
+    "test": "NODE_ENV=test yarn run db:migrate && NODE_ENV=test  nyc --reporter=text --reporter=lcov mocha --require babel-polyfill --require @babel/register tests/*  --timeout 10000 --exit",
     "start": "NODE_ENV=development nodemon --exec babel-node index.js",
     "db:migrate": "node_modules/.bin/sequelize db:migrate",
     "db:reset": "NODE_ENV=test node_modules/.bin/sequelize db:migrate:undo:all"
@@ -32,6 +32,7 @@
     "express-session": "^1.15.6",
     "joi": "^14.3.1",
     "jsonwebtoken": "^8.3.0",
+    "lodash": "^4.17.11",
     "method-override": "^2.3.10",
     "methods": "^1.1.2",
     "mongoose": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -22,26 +22,21 @@
     "@sendgrid/mail": "^6.3.1",
     "babel-preset-airbnb": "^3.2.0",
     "bcrypt": "^3.0.3",
-    "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "dotenv": "^6.2.0",
-    "ejs": "^2.6.1",
     "errorhandler": "^1.5.0",
-    "express": "^4.16.3",
-    "express-jwt": "^5.3.1",
+    "express": "^4.16.4",
     "express-session": "^1.15.6",
     "joi": "^14.3.1",
     "jsonwebtoken": "^8.3.0",
     "lodash": "^4.17.11",
     "method-override": "^2.3.10",
-    "methods": "^1.1.2",
     "morgan": "^1.9.0",
     "nock": "^10.0.6",
     "nodemon": "^1.18.9",
     "opn": "^5.4.0",
     "passport": "^0.4.0",
     "passport-jwt": "^4.0.0",
-    "passport-local": "^1.0.0",
     "pg": "^7.8.0",
     "pg-hstore": "^2.3.2",
     "request": "^2.87.0",
@@ -49,9 +44,7 @@
     "sequelize-cli": "^5.4.0",
     "sinon": "^7.2.4",
     "slug": "^0.9.3",
-    "swagger-ui-express": "^4.0.2",
-    "underscore": "^1.9.1",
-    "uuid": "^3.3.2"
+    "swagger-ui-express": "^4.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
@@ -65,13 +58,10 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-jsdoc": "^4.1.0",
     "eslint-plugin-prettier": "^3.0.1",
     "faker": "^4.1.0",
     "mocha": "^5.2.0",
-    "nock": "^10.0.6",
     "nyc": "^13.2.0",
-    "prettier": "^1.16.4",
-    "rosie": "^2.0.1"
+    "prettier": "^1.16.4"
   }
 }

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -9,7 +9,7 @@ import ReportArticleController from "../controllers/reportArticleController";
 
 const article = Router();
 
-article.get("/articles/:slug", Article.findOneArticle);
+article.get("/articles/:slug", optionalAuth, Article.findOneArticle);
 article.get("/articles", optionalAuth, Article.findAll);
 
 article

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -5,20 +5,26 @@ import ArticleLikeController from "../controllers/articleLikesController";
 import BookmarkController from "../controllers/bookmarkController";
 import ReportArticleController from "../controllers/reportArticleController";
 import checkAuth from "../middlewares/checkAuth";
+import optionalAuth from "../middlewares/optionalAuth";
 
 const article = Router();
 
-article.post("/articles/:slug/bookmark", checkAuth, BookmarkController.bookmark);
-article.post("/articles/:slug/likes", ArticleLikeController.like);
-article.post("/articles/:slug/dislikes", ArticleLikeController.dislike);
-article.get("/articles/:slug/likes", ArticleLikeController.getArticleLikes);
+article.get("/articles", optionalAuth, Article.findAll);
+article.put("/articles/:slug", checkAuth, Article.update);
+article.delete("/articles/:slug", checkAuth, Article.delete);
+article.post("/articles/:slug/bookmark", checkAuth, Article.bookmark);
+article.post("/articles/:slug/likes", checkAuth, ArticleLikeController.like);
+article.post("/articles/:slug/dislikes", checkAuth, ArticleLikeController.dislike);
+article.get(
+  "/articles/:slug/likes",
+  checkAuth,
+  ArticleLikeController.getArticleLikes
+);
 
 article
   .post("/articles", checkAuth, Article.create)
   .get("/articles/:slug", Article.findOneArticle);
-article.put(
-  "/articles/:slug/report",
-  articleValidator.validateArticle,
-  ReportArticleController.reportArticle
-);
+article.post("/articles", Article.create);
+article.post("/articles/:slug/bookmark", Article.bookmark);
+article.put("/articles/:slug/report", checkAuth, Article.reportArticle);
 export default article;

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -11,7 +11,7 @@ const article = Router();
 
 article.get("/articles", optionalAuth, Article.findAll);
 article.put("/articles/:slug", checkAuth, Article.update);
-article.delete("/articles/:slug", checkAuth, Article.delete);
+article.delete("/articles/:slug", checkAuth, Article.deleteOne);
 article.post("/articles/:slug/bookmark", checkAuth, Article.bookmark);
 article.post("/articles/:slug/likes", checkAuth, ArticleLikeController.like);
 article.post("/articles/:slug/dislikes", checkAuth, ArticleLikeController.dislike);

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -9,25 +9,23 @@ import ReportArticleController from "../controllers/reportArticleController";
 
 const article = Router();
 
+article.get("/articles/:slug", Article.findOneArticle);
 article.get("/articles", optionalAuth, Article.findAll);
-article.put("/articles/:slug", checkAuth, Article.update);
-article.delete("/articles/:slug", checkAuth, Article.deleteOne);
-article.post("/articles/:slug/bookmark", checkAuth, BookmarkController.bookmark);
-article.post("/articles/:slug/likes", checkAuth, ArticleLikeController.like);
-article.post("/articles/:slug/dislikes", checkAuth, ArticleLikeController.dislike);
-article.get(
-  "/articles/:slug/likes",
-  checkAuth,
-  ArticleLikeController.getArticleLikes
-);
 
 article
-  .post("/articles", checkAuth, Article.create)
-  .get("/articles/:slug", Article.findOneArticle);
-article.put(
-  "/articles/:slug/report",
-  checkAuth,
-  articleValidator.validateArticle,
-  ReportArticleController.reportArticle
-);
+  .use(checkAuth)
+  .post("/articles", Article.create)
+  .post("/articles/:slug/bookmark", BookmarkController.bookmark)
+  .post("/articles/:slug/likes", ArticleLikeController.like)
+  .post("/articles/:slug/dislikes", ArticleLikeController.dislike)
+  .get("/articles/:slug/likes", ArticleLikeController.getArticleLikes)
+  .put(
+    "/articles/:slug/report",
+    articleValidator.validateArticle,
+    ReportArticleController.reportArticle
+  )
+  .route("/articles/:slug")
+  .put(Article.update)
+  .delete(Article.deleteOne);
+
 export default article;

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -2,17 +2,17 @@ import { Router } from "express";
 import Article from "../controllers/articlesController";
 import articleValidator from "../middlewares/articleValidator";
 import ArticleLikeController from "../controllers/articleLikesController";
-import BookmarkController from "../controllers/bookmarkController";
-import ReportArticleController from "../controllers/reportArticleController";
 import checkAuth from "../middlewares/checkAuth";
 import optionalAuth from "../middlewares/optionalAuth";
+import BookmarkController from "../controllers/bookmarkController";
+import ReportArticleController from "../controllers/reportArticleController";
 
 const article = Router();
 
 article.get("/articles", optionalAuth, Article.findAll);
 article.put("/articles/:slug", checkAuth, Article.update);
 article.delete("/articles/:slug", checkAuth, Article.deleteOne);
-article.post("/articles/:slug/bookmark", checkAuth, Article.bookmark);
+article.post("/articles/:slug/bookmark", checkAuth, BookmarkController.bookmark);
 article.post("/articles/:slug/likes", checkAuth, ArticleLikeController.like);
 article.post("/articles/:slug/dislikes", checkAuth, ArticleLikeController.dislike);
 article.get(
@@ -24,7 +24,10 @@ article.get(
 article
   .post("/articles", checkAuth, Article.create)
   .get("/articles/:slug", Article.findOneArticle);
-article.post("/articles", Article.create);
-article.post("/articles/:slug/bookmark", Article.bookmark);
-article.put("/articles/:slug/report", checkAuth, Article.reportArticle);
+article.put(
+  "/articles/:slug/report",
+  checkAuth,
+  articleValidator.validateArticle,
+  ReportArticleController.reportArticle
+);
 export default article;

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -1,10 +1,12 @@
 import { Router } from "express";
 import Comment from "../controllers/commentController";
+import checkAuth from "../middlewares/checkAuth";
 
 const comment = Router();
 
+comment.use(checkAuth);
 comment.post("/articles/:slug/comments", Comment.create);
 comment.post("/articles/:slug/comments/:commentId/likes", Comment.like);
 comment.get("/articles/:slug/comments/:commentId/likes", Comment.getCommentLikes);
-
+ 
 export default comment;

--- a/routes/index.js
+++ b/routes/index.js
@@ -11,8 +11,8 @@ const router = Router();
 
 router.use(userRouters);
 router.use(profileRouter);
-router.use(checkAuth, commentRoutes);
 router.use(articleRoutes);
-router.use(checkAuth, articleRoutes);
 router.use(checkAuth, ratingRouters);
+router.use(commentRoutes);
+
 export default router;

--- a/services/sendgrid.js
+++ b/services/sendgrid.js
@@ -8,7 +8,7 @@ export const sendEmail = async (email, subject, emailTemplate) => {
   const message = {
     to: email,
     from: { email: process.env.DEVELOPER_EMAIL, name: "Author's Heaven" },
-    subject: subject,
+    subject,
     html: emailTemplate
   };
 

--- a/swagger.json
+++ b/swagger.json
@@ -17,21 +17,13 @@
       "description": "API for users in the system"
     }
   ],
-  "schemes": [
-    "http"
-  ],
-  "consumes": [
-    "application/json"
-  ],
-  "produces": [
-    "application/json"
-  ],
+  "schemes": ["http"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
   "paths": {
     "/users": {
       "post": {
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "description": "Create new user in system",
         "parameters": [
           {
@@ -43,9 +35,7 @@
             }
           }
         ],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "New user is created",
@@ -56,9 +46,7 @@
         }
       },
       "get": {
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "summary": "Get all users in system",
         "responses": {
           "200": {
@@ -81,9 +69,7 @@
         }
       ],
       "get": {
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "summary": "Get user with given ID",
         "responses": {
           "200": {
@@ -96,9 +82,7 @@
       },
       "delete": {
         "summary": "Delete user with given ID",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "responses": {
           "200": {
             "description": "User is deleted",
@@ -110,9 +94,7 @@
       },
       "put": {
         "summary": "Update user with give ID",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user",
@@ -135,9 +117,7 @@
     },
     "/users/confirm/{auth_token}": {
       "get": {
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "summary": "Send email send email verification",
         "description": "This helps in verifying account created ",
         "parameters": [
@@ -217,9 +197,7 @@
     },
     "/users/resend": {
       "get": {
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "summary": "Re-send email verification",
         "description": "This helps in resend email verification just in case email did not come.",
         "parameters": [
@@ -299,9 +277,7 @@
     },
     "/articles": {
       "post": {
-        "tags": [
-          "Articles"
-        ],
+        "tags": ["Articles"],
         "summary": "Create an article",
         "description": "This helps the user to create a new article",
         "parameters": [
@@ -322,13 +298,74 @@
             }
           }
         }
+      },
+      "get": {
+        "tags": ["Articles"],
+        "summary": "Get created articles",
+        "description": "This helps the user to fetch all the created articles",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Article"
+            }
+          }
+        }
+      }
+    },
+    "/articles/{slug}": {
+      "put": {
+        "tags": ["Articles"],
+        "summary": "Update an article",
+        "description": "This helps the author to update their article",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "Article slug property",
+            "schema": {
+              "$ref": "#/definitions/Article"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "CREATED",
+            "schema": {
+              "$ref": "#/definitions/Article"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Articles"],
+        "summary": "Delete an article",
+        "description": "This helps the author to delete their article",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "Article slug property",
+            "schema": {
+              "$ref": "#/definitions/Article"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "CREATED",
+            "schema": {
+              "$ref": "#/definitions/Article"
+            }
+          }
+        }
       }
     },
     "/articles/{slug}/bookmark": {
       "post": {
-        "tags": [
-          "Articles"
-        ],
+        "tags": ["Articles"],
         "summary": "Bookmark an article",
         "description": "This helps the user bookmark an article for reading it later",
         "parameters": [
@@ -354,9 +391,7 @@
     },
     "/article/{articleId}/share/fb": {
       "get": {
-        "tags": [
-          "Articles"
-        ],
+        "tags": ["Articles"],
         "summary": "Share article on facebook",
         "description": "This helps the user share their preferred article on facebook ",
         "parameters": [
@@ -388,9 +423,7 @@
     },
     "/article/{articleId}/share/email": {
       "get": {
-        "tags": [
-          "Articles"
-        ],
+        "tags": ["Articles"],
         "summary": "Share article on email",
         "description": "This helps the user share their preferred article on email ",
         "parameters": [
@@ -422,9 +455,7 @@
     },
     "/article/{articleId}/share/twitter": {
       "get": {
-        "tags": [
-          "Articles"
-        ],
+        "tags": ["Articles"],
         "summary": "Share article on twitter",
         "description": "This helps the user share their preferred article on twitter ",
         "parameters": [
@@ -465,9 +496,7 @@
         }
       ],
       "get": {
-        "tags": [
-          "Ratings"
-        ],
+        "tags": ["Ratings"],
         "summary": "Get the ratings for the given article",
         "responses": {
           "200": {
@@ -480,9 +509,7 @@
       },
       "put": {
         "summary": "Update  a given rating ",
-        "tags": [
-          "Ratings"
-        ],
+        "tags": ["Ratings"],
         "parameters": [
           {
             "name": "rating",
@@ -502,55 +529,56 @@
           }
         }
       }
-  },
-  "definitions": {
-    "User": {
-      "type": "object",
-      "properties": {
-        "user": {
+    },
+    "definitions": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Users": {
+        "type": "array",
+        "items": {
           "type": "object",
           "properties": {
-            "email": {
+            "firstName": {
               "type": "string"
             }
           }
         }
-      }
-    },
-    "Users": {
-      "type": "array",
-      "items": {
+      },
+      "Article": {
         "type": "object",
         "properties": {
-          "firstName": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Article": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "example": "An American ate the African chicken"
-        },
-        "body": {
-          "type": "string",
-          "example": "Ever wonder how the guy got his pocket empty because of the meal?"
-        },
-        "description": {
-          "type": "string",
-          "example": "'It was so delicious'. said the white man who ate the African chicken for his first time in Rwanda."
-        },
-        "tagsList": {
-          "type": "array",
-          "items": {
+          "title": {
             "type": "string",
-            "example": "javaScript"
+            "example": "An American ate the African chicken"
+          },
+          "body": {
+            "type": "string",
+            "example": "Ever wonder how the guy got his pocket empty because of the meal?"
+          },
+          "description": {
+            "type": "string",
+            "example": "'It was so delicious'. said the white man who ate the African chicken for his first time in Rwanda."
+          },
+          "tagsList": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "javaScript"
+            }
           }
         }
       }
     }
   }
-}}
+}

--- a/tests/helpers/testData.js
+++ b/tests/helpers/testData.js
@@ -620,10 +620,13 @@ const opnResponse = {
     }
   ]
 };
+
+const fakeToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InBhY2lAZW1haWwuY29tIiwidXNlcm5hbWUiOiJwYWNpIiwiaWQiOiIzNjRlYmFjNy1jYjQ1LTQ5ZDQtODlmNC1lY2Y5MWE5OTczZjIiLCJpYXQiOjE1NTIwMDEwNTB9.mPtpx6r62aXEYWyWFYYkiCdTEPR4ECfZrB1wJ30fXXM`;
 export {
   newArticle,
   newComment,
   users,
+  fakeToken,
   tokenEmailVerication,
   sendGridResponse,
   article,

--- a/tests/helpers/testData.js
+++ b/tests/helpers/testData.js
@@ -620,13 +620,10 @@ const opnResponse = {
     }
   ]
 };
-
-const fakeToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InBhY2lAZW1haWwuY29tIiwidXNlcm5hbWUiOiJwYWNpIiwiaWQiOiIzNjRlYmFjNy1jYjQ1LTQ5ZDQtODlmNC1lY2Y5MWE5OTczZjIiLCJpYXQiOjE1NTIwMDEwNTB9.mPtpx6r62aXEYWyWFYYkiCdTEPR4ECfZrB1wJ30fXXM`;
 export {
   newArticle,
   newComment,
   users,
-  fakeToken,
   tokenEmailVerication,
   sendGridResponse,
   article,

--- a/tests/integration/article.test.js
+++ b/tests/integration/article.test.js
@@ -6,8 +6,17 @@ import constants from "../../helpers/constants";
 
 let token;
 
+let fakeToken;
 const { dummyUser } = users;
-const { UNAUTHORIZED, CREATED, BAD_REQUEST } = constants.statusCode;
+const {
+  UNAUTHORIZED,
+  CREATED,
+  BAD_REQUEST,
+  OK,
+  NOT_FOUND,
+  INTERNAL_SERVER_ERROR
+} = constants.statusCode;
+let validSlug;
 chai.use(chaiHttp);
 
 chai.use(chaiHttp);
@@ -31,94 +40,358 @@ before(done => {
     });
 });
 
-describe("Create a new article", () => {
-  it("should create the article and return the success message", done => {
-    chai
-      .request(app)
-      .post("/api/v1/articles")
-      .set("Authorization", `Bearer ${token}`)
-      .send(newArticle)
-      .end((err, res) => {
-        expect(res.status).equals(CREATED);
-        expect(res.body.message).to.contain("Article created");
-        expect(res.body).to.haveOwnProperty("article");
-        expect(res.body.article).to.haveOwnProperty("createdAt");
-        expect(res.body.article).to.haveOwnProperty("title");
-        expect(res.body.article.title).to.contain(newArticle.title);
-        expect(res.body.article.readTime).equals(1);
-        done();
-      });
-  });
+describe("# Articles endpoints", () => {
+  let createdArticle;
+  describe("Create a new article", () => {
+    it("should create the article and return the success message", done => {
+      chai
+        .request(app)
+        .post("/api/v1/articles")
+        .set("Authorization", `Bearer ${token}`)
+        .send(newArticle)
+        .end((err, res) => {
+          expect(res.status).equals(CREATED);
+          expect(res.body.message).to.contain("Article created");
+          expect(res.body).to.haveOwnProperty("article");
+          expect(res.body.article).to.haveOwnProperty("createdAt");
+          expect(res.body.article).to.haveOwnProperty("title");
+          expect(res.body.article.title).to.contain(newArticle.title);
+          expect(res.body.article.readTime).equals(1);
+          done();
+        });
+    });
 
-  it("should deny the request if no access-token provided ", done => {
-    chai
-      .request(app)
-      .post("/api/v1/articles")
-      .send(newArticle)
-      .end((err, res) => {
-        expect(res.status).equals(UNAUTHORIZED);
-        expect(res.body.message).to.contain("Please provide a token");
-        done();
+    describe("POST /articles/:slug/bookmark", () => {
+      it("should bookmark the article and return the success message", done => {
+        const { article } = createdArticle;
+        chai
+          .request(app)
+          .post(`/api/v1/articles/${article.slug}/bookmark`)
+          .set("Authorization", `Bearer ${token}`)
+          .end((err, res) => {
+            expect(res.status).equals(CREATED);
+            expect(res.body.message).to.contain("Article bookmarked");
+            expect(res.body).to.haveOwnProperty("bookmark");
+            expect(res.body.bookmark).to.be.an("object");
+            expect(res.body.bookmark).to.haveOwnProperty("createdAt");
+            expect(res.body.bookmark.articleId).equals(article.id);
+            done();
+          });
       });
-  });
 
-  it("should decline creating the article if no title provided", done => {
-    const { title, ...rest } = newArticle;
-    chai
-      .request(app)
-      .post("/api/v1/articles")
-      .set("Authorization", `Bearer ${token}`)
-      .send(rest)
-      .end((err, res) => {
-        expect(res.status).equals(BAD_REQUEST);
-        expect(res.body.message).to.contain('"title" is required');
-        done();
+      it("should deny bookmarking if no access-token provided", done => {
+        const { article } = createdArticle;
+        chai
+          .request(app)
+          .post(`/api/v1/articles/${article.slug}/bookmark`)
+          .end((err, res) => {
+            expect(res.status).equals(UNAUTHORIZED);
+            expect(res.body.message).to.contain("Please provide a token");
+            done();
+          });
       });
-  });
 
-  it("should decline creating the article if no body provided", done => {
-    const { body, ...rest } = newArticle;
-    chai
-      .request(app)
-      .post("/api/v1/articles")
-      .set("Authorization", `Bearer ${token}`)
-      .send(rest)
-      .end((err, res) => {
-        expect(res.status).equals(BAD_REQUEST);
-        expect(res.body.message).to.contain('"body" is required');
-        done();
+      it("should decline bookmarking the article which doesn't exist", done => {
+        const { article } = createdArticle;
+        chai
+          .request(app)
+          .post(`/api/v1/articles/${article.slug}fs1/bookmark`)
+          .set("Authorization", `Bearer ${token}`)
+          .end((err, res) => {
+            expect(res.status).equals(NOT_FOUND);
+            expect(res.body.message).to.contain("The article with this slug");
+            done();
+          });
       });
-  });
 
-  it("should decline creating the article if no description provided", done => {
-    const { description, ...rest } = newArticle;
-    chai
-      .request(app)
-      .post("/api/v1/articles")
-      .set("Authorization", `Bearer ${token}`)
-      .send(rest)
-      .end((err, res) => {
-        expect(res.status).equals(BAD_REQUEST);
-        expect(res.body.message).to.contain('"description" is required');
-        done();
+      it("should delete the bookmark if it existed", done => {
+        const { article } = createdArticle;
+        chai
+          .request(app)
+          .post(`/api/v1/articles/${article.slug}/bookmark`)
+          .set("Authorization", `Bearer ${token}`)
+          .end((err, res) => {
+            expect(res.status).equals(OK);
+            expect(res.body.message).to.contain("Bookmark deleted");
+            done();
+          });
       });
-  });
+    });
 
-  it("should create an article with no tagsList", done => {
-    const { tagsList, ...rest } = newArticle;
-    chai
-      .request(app)
-      .post("/api/v1/articles")
-      .set("Authorization", `Bearer ${token}`)
-      .send(rest)
-      .end((err, res) => {
-        expect(res.status).equals(CREATED);
-        expect(res.body.message).to.contain("Article created");
-        expect(res.body).to.haveOwnProperty("article");
-        expect(res.body.article).to.haveOwnProperty("createdAt");
-        expect(res.body.article).to.haveOwnProperty("title");
-        expect(res.body.article.title).to.contain(newArticle.title);
-        done();
+    describe("Share Articles endpoints", () => {
+      it("should be ready to be posted on twitter", done => {
+        chai
+          .request(app)
+          .get(`/api/v1/articles/${validSlug}/share/twitter`)
+          .set("Authorization", `Bearer ${token}`)
+          .end((err, res) => {
+            expect(res.status).equals(OK);
+            expect(res.body.message).to.contain(
+              "Article ready to be posted on twitter"
+            );
+            done();
+          });
       });
+      it("should be ready to be posted on facebook", done => {
+        chai
+          .request(app)
+          .get(`/api/v1/articles/${validSlug}/share/fb`)
+          .set("Authorization", `Bearer ${token}`)
+          .end((err, res) => {
+            expect(res.status).equals(OK);
+            expect(res.body.message).to.contain(
+              "Article ready to be posted on facebook"
+            );
+            done();
+          });
+      });
+      it("should be ready to be posted on linkedIn", done => {
+        chai
+          .request(app)
+          .get(`/api/v1/articles/${validSlug}/share/linkedIn`)
+          .set("Authorization", `Bearer ${token}`)
+          .end((err, res) => {
+            expect(res.status).equals(OK);
+            expect(res.body.message).to.contain(
+              "Article ready to be posted on linkedIn"
+            );
+            done();
+          });
+      });
+      it("should be ready to be posted on email", done => {
+        chai
+          .request(app)
+          .get(`/api/v1/articles/${validSlug}/share/email`)
+          .set("Authorization", `Bearer ${token}`)
+          .end((err, res) => {
+            expect(res.status).equals(OK);
+            expect(res.body.message).to.contain(
+              "Article ready to be posted on Email"
+            );
+            done();
+          });
+      });
+    });
+    describe("Fetching all articles", () => {
+      it("should return a list of all created articles", done => {
+        chai
+          .request(app)
+          .get(`/api/v1/articles`)
+          .set("Authorization", `Bearer ${token}`)
+          .end((err, res) => {
+            expect(res.status).equals(OK);
+            expect(res.body.message).to.contain("Successful");
+            expect(res.body)
+              .to.haveOwnProperty("articles")
+              .to.be.an("array");
+            expect(res.body)
+              .to.haveOwnProperty("articlesCount")
+              .to.be.a("number");
+            res.body.articles.map(article => {
+              expect(article).to.have.any.keys(
+                "slug",
+                "title",
+                "description",
+                "body",
+                "tagsList",
+                "favorited",
+                "favoritesCount",
+                "author"
+              );
+              expect(article.tagsList).to.be.an("array");
+              expect(article.favoritesCount).to.be.a("number");
+              expect(article.favorited).to.be.a("boolean");
+              return expect(article.author)
+                .to.be.an("object")
+                .to.haveOwnProperty("username")
+                .to.be.a("string");
+            });
+            done();
+          });
+      });
+
+      it("should return a list of all created articles even when no token provided", done => {
+        chai
+          .request(app)
+          .get(`/api/v1/articles`)
+          .end((err, res) => {
+            expect(res.status).equals(OK);
+            expect(res.body.message).to.contain("Successful");
+            expect(res.body)
+              .to.haveOwnProperty("articles")
+              .to.be.an("array");
+            expect(res.body)
+              .to.haveOwnProperty("articlesCount")
+              .to.be.a("number");
+
+            res.body.articles.map(article => {
+              expect(article).to.have.any.keys(
+                "slug",
+                "title",
+                "description",
+                "body",
+                "tagsList",
+                "favorited",
+                "favoritesCount",
+                "author"
+              );
+              expect(article.tagsList).to.be.an("array");
+              expect(article.favoritesCount).to.be.a("number");
+              expect(article.favorited).to.be.a("boolean");
+              return expect(article.author)
+                .to.be.an("object")
+                .to.haveOwnProperty("username")
+                .to.be.a("string");
+            });
+
+            done();
+          });
+      });
+
+      it("should filter articles by author", done => {
+        chai
+          .request(app)
+          .get(`/api/v1/articles?author=${dummyUser.username}`)
+          .end((err, res) => {
+            expect(res.status).equals(OK);
+            expect(res.body.message).to.contain("Successful");
+            expect(res.body)
+              .to.haveOwnProperty("articles")
+              .to.be.an("array");
+            expect(res.body)
+              .to.haveOwnProperty("articlesCount")
+              .to.be.a("number");
+            res.body.articles.map(article => {
+              expect(article).to.have.any.keys(
+                "slug",
+                "title",
+                "description",
+                "body",
+                "tagsList",
+                "favorited",
+                "favoritesCount",
+                "author"
+              );
+              return expect(article.author)
+                .to.be.an("object")
+                .to.haveOwnProperty("username")
+                .to.be.a("string")
+                .to.equal(dummyUser.username);
+            });
+            done();
+          });
+      });
+    });
+
+    describe("Updating and deleting a specific article", () => {
+      before(done => {
+        chai
+          .request(app)
+          .post("/api/v1/users")
+          .send({
+            email: "fake@email.com",
+            username: "fake",
+            password: "243hjgudsgdgh"
+          })
+          .end(error => {
+            if (!error) {
+              chai
+                .request(app)
+                .post("/api/v1/users/login")
+                .send({ email: "fake@email.com", password: "243hjgudsgdgh" })
+                .end((err, res) => {
+                  if (!err) fakeToken = res.body.token;
+                  done(err || undefined);
+                });
+            }
+          });
+      });
+
+      describe("Updating a specific article", () => {
+        it("should add the new tags on an article", done => {
+          chai
+            .request(app)
+            .put(`/api/v1/articles/${validSlug}`)
+            .set("Authorization", `Bearer ${token}`)
+            .send({ tagsList: ["politics", "music", "love"] })
+            .end((err, res) => {
+              expect(res.status).equals(CREATED);
+              expect(res.body.message).to.contain("Updated");
+              expect(res.body)
+                .to.haveOwnProperty("article")
+                .to.be.an("object");
+              done();
+            });
+        });
+
+        it("should throw the error if the current user is not the author of that article", done => {
+          chai
+            .request(app)
+            .put(`/api/v1/articles/${validSlug}`)
+            .set("Authorization", `Bearer ${fakeToken}`)
+            .end((err, res) => {
+              expect(res.status).equals(UNAUTHORIZED);
+              expect(res.body.message).to.contain(
+                "You can only update the article you authored"
+              );
+              done();
+            });
+        });
+
+        it("should throw the bad request error if the description is invalid", done => {
+          chai
+            .request(app)
+            .put(`/api/v1/articles/${validSlug}`)
+            .set("Authorization", `Bearer ${token}`)
+            .send({ description: "Love" })
+            .end((err, res) => {
+              expect(res.status).equals(BAD_REQUEST);
+              expect(res.body.message).to.contain(
+                '"description" length must be at least 10 characters long'
+              );
+              done();
+            });
+        });
+      });
+
+      describe("Deleting a specific article", () => {
+        it("should throw the error if the current user is not the author of that article", done => {
+          chai
+            .request(app)
+            .delete(`/api/v1/articles/${validSlug}`)
+            .set("Authorization", `Bearer ${fakeToken}`)
+            .end((err, res) => {
+              expect(res.status).equals(UNAUTHORIZED);
+              expect(res.body.message).to.contain(
+                "You can only delete the article you authored"
+              );
+              done();
+            });
+        });
+
+        it(`should delete the article with slug ${validSlug}`, done => {
+          chai
+            .request(app)
+            .delete(`/api/v1/articles/${validSlug}`)
+            .set("Authorization", `Bearer ${token}`)
+            .end((err, res) => {
+              expect(res.status).equals(OK);
+              expect(res.body.message).to.contain("Deleted");
+              done();
+            });
+        });
+
+        it("should throw the error if article is not found", done => {
+          chai
+            .request(app)
+            .delete(`/api/v1/articles/${validSlug}l`)
+            .set("Authorization", `Bearer ${token}`)
+            .end((err, res) => {
+              expect(res.status).equals(INTERNAL_SERVER_ERROR);
+              done();
+            });
+        });
+      });
+    });
   });
 });

--- a/tests/integration/article.test.js
+++ b/tests/integration/article.test.js
@@ -201,6 +201,87 @@ describe("# Articles endpoints", () => {
           done();
         });
     });
+
+    describe("Pagination (limit the number of articles to be returned)", () => {
+      it("should return the exact number of articles specified by the limit param", done => {
+        chai
+          .request(app)
+          .get(`/api/v1/articles?limit=2`)
+          .end((err, res) => {
+            expect(res.status).equals(OK);
+            expect(res.body.message).to.contain("Successful");
+            expect(res.body)
+              .to.haveOwnProperty("articles")
+              .to.be.an("array");
+            expect(res.body)
+              .to.haveOwnProperty("articlesCount")
+              .to.be.a("number");
+            expect(res.body.articles.length).to.equal(2);
+            expect(res.body.articlesCount).to.equal(2);
+            done();
+          });
+      });
+
+      it("should return (x) articles for the first page, and y articles for the second page", done => {
+        chai
+          .request(app)
+          .get(`/api/v1/articles?limit=1&page=1`)
+          .end((err, page1) => {
+            chai
+              .request(app)
+              .get(`/api/v1/articles?limit=2&page=2`)
+              .end((error, page2) => {
+                expect(page1.status).equals(OK);
+                expect(page1.body.message).to.contain("Successful");
+                expect(page1.body)
+                  .to.haveOwnProperty("articles")
+                  .to.be.an("array");
+                expect(page1.body)
+                  .to.haveOwnProperty("articlesCount")
+                  .to.be.a("number");
+                expect(page1.body.articles.length).to.equal(1);
+                expect(page1.body.articlesCount).to.equal(1);
+                expect(page2.status).equals(OK);
+                expect(page2.body.message).to.contain("Successful");
+                expect(page2.body)
+                  .to.haveOwnProperty("articles")
+                  .to.be.an("array");
+                expect(page2.body)
+                  .to.haveOwnProperty("articlesCount")
+                  .to.be.a("number");
+                expect(page2.body.articles.length).to.equal(2);
+                expect(page2.body.articlesCount).to.equal(2);
+                expect(page1.body.articles).not.to.equal(page2.body.articles);
+                done();
+              });
+          });
+      });
+    });
+  });
+
+  describe("Updating and deleting a specific article", () => {
+    before(done => {
+      chai
+        .request(app)
+        .post("/api/v1/users")
+        .send({
+          email: "fake@email.com",
+          username: "fake",
+          password: "243hjgudsgdgh"
+        })
+        .end(error => {
+          if (!error) {
+            chai
+              .request(app)
+              .post("/api/v1/users/login")
+              .send({ email: "fake@email.com", password: "243hjgudsgdgh" })
+              .end((err, res) => {
+                if (!err) fakeToken = res.body.token;
+                done(err || undefined);
+              });
+          }
+        });
+    });
   });
 
   describe("Updating and deleting a specific article", () => {

--- a/tests/integration/article.test.js
+++ b/tests/integration/article.test.js
@@ -61,23 +61,262 @@ describe("# Articles endpoints", () => {
         });
     });
 
-    describe("POST /articles/:slug/bookmark", () => {
-      it("should bookmark the article and return the success message", done => {
-        const { article } = createdArticle;
-        chai
-          .request(app)
-          .post(`/api/v1/articles/${article.slug}/bookmark`)
-          .set("Authorization", `Bearer ${token}`)
-          .end((err, res) => {
-            expect(res.status).equals(CREATED);
-            expect(res.body.message).to.contain("Article bookmarked");
-            expect(res.body).to.haveOwnProperty("bookmark");
-            expect(res.body.bookmark).to.be.an("object");
-            expect(res.body.bookmark).to.haveOwnProperty("createdAt");
-            expect(res.body.bookmark.articleId).equals(article.id);
-            done();
+    it("should deny the request if no access-token provided ", done => {
+      chai
+        .request(app)
+        .post("/api/v1/articles")
+        .send(newArticle)
+        .end((err, res) => {
+          expect(res.status).equals(UNAUTHORIZED);
+          expect(res.body.message).to.contain("Please provide a token");
+          done();
+        });
+    });
+
+    it("should decline creating the article if no title provided", done => {
+      const { title, ...rest } = newArticle;
+      chai
+        .request(app)
+        .post("/api/v1/articles")
+        .set("Authorization", `Bearer ${token}`)
+        .send(rest)
+        .end((err, res) => {
+          expect(res.status).equals(BAD_REQUEST);
+          expect(res.body.message).to.contain('"title" is required');
+          done();
+        });
+    });
+
+    it("should decline creating the article if no body provided", done => {
+      const { body, ...rest } = newArticle;
+      chai
+        .request(app)
+        .post("/api/v1/articles")
+        .set("Authorization", `Bearer ${token}`)
+        .send(rest)
+        .end((err, res) => {
+          expect(res.status).equals(BAD_REQUEST);
+          expect(res.body.message).to.contain('"body" is required');
+          done();
+        });
+    });
+
+    it("should decline creating the article if no description provided", done => {
+      const { description, ...rest } = newArticle;
+      chai
+        .request(app)
+        .post("/api/v1/articles")
+        .set("Authorization", `Bearer ${token}`)
+        .send(rest)
+        .end((err, res) => {
+          expect(res.status).equals(BAD_REQUEST);
+          expect(res.body.message).to.contain('"description" is required');
+          done();
+        });
+    });
+
+    it("should create an article with no tagsList", done => {
+      const { tagsList, ...rest } = newArticle;
+      chai
+        .request(app)
+        .post("/api/v1/articles")
+        .set("Authorization", `Bearer ${token}`)
+        .send(rest)
+        .end((err, res) => {
+          expect(res.status).equals(CREATED);
+          expect(res.body.message).to.contain("Article created");
+          expect(res.body).to.haveOwnProperty("article");
+          expect(res.body.article).to.haveOwnProperty("createdAt");
+          expect(res.body.article).to.haveOwnProperty("title");
+          expect(res.body.article.title).to.contain(newArticle.title);
+          done();
+        });
+    });
+  });
+  describe("Report an article endpoint", () => {
+    it("should be report an article", done => {
+      chai
+        .request(app)
+        .put(`/api/v1/articles/${validSlug}/report`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ description: "abusive" })
+        .end((err, res) => {
+          console.log("FDJVGHDFJICHGIJSDHJDFJJG", res.body);
+          expect(res.status).equals(OK);
+          expect(res.body.message).to.contain("Article reported");
+          done();
+        });
+    });
+    it("should report an article", done => {
+      chai
+        .request(app)
+        .put(`/api/v1/articles/${validSlug}/report`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ description: "abusive" })
+        .end((err, res) => {
+          expect(res.status).equals(OK);
+          expect(res.body.message).to.contain("Article reported");
+          done();
+        });
+    });
+    it("should should ask for description", done => {
+      chai
+        .request(app)
+        .put(`/api/v1/articles/${validSlug}/report`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({ description: "" })
+        .end((err, res) => {
+          expect(res.status).equals(BAD_REQUEST);
+          expect(res.body.message).to.contain("Please, give a reason");
+          done();
+        });
+    });
+  });
+
+  describe("POST /articles/:slug/bookmark", () => {
+    it("should bookmark the article and return the success message", done => {
+      const { article } = createdArticle;
+      chai
+        .request(app)
+        .post(`/api/v1/articles/${article.slug}/bookmark`)
+        .set("Authorization", `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).equals(CREATED);
+          expect(res.body.message).to.contain("Article bookmarked");
+          expect(res.body).to.haveOwnProperty("bookmark");
+          expect(res.body.bookmark).to.be.an("object");
+          expect(res.body.bookmark).to.haveOwnProperty("createdAt");
+          expect(res.body.bookmark.articleId).equals(article.id);
+          done();
+        });
+    });
+
+    it("should deny bookmarking if no access-token provided", done => {
+      const { article } = createdArticle;
+      chai
+        .request(app)
+        .post(`/api/v1/articles/${article.slug}/bookmark`)
+        .end((err, res) => {
+          expect(res.status).equals(UNAUTHORIZED);
+          expect(res.body.message).to.contain("Please provide a token");
+          done();
+        });
+    });
+
+    it("should decline bookmarking the article which doesn't exist", done => {
+      const { article } = createdArticle;
+      chai
+        .request(app)
+        .post(`/api/v1/articles/${article.slug}fs1/bookmark`)
+        .set("Authorization", `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).equals(NOT_FOUND);
+          expect(res.body.message).to.contain("The article with this slug");
+          done();
+        });
+    });
+
+    it("should delete the bookmark if it existed", done => {
+      const { article } = createdArticle;
+      chai
+        .request(app)
+        .post(`/api/v1/articles/${article.slug}/bookmark`)
+        .set("Authorization", `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).equals(OK);
+          expect(res.body.message).to.contain("Bookmark deleted");
+          done();
+        });
+    });
+  });
+
+  describe("Share Articles endpoints", () => {
+    it("should be ready to be posted on twitter", done => {
+      chai
+        .request(app)
+        .get(`/api/v1/articles/${validSlug}/share/twitter`)
+        .set("Authorization", `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).equals(OK);
+          expect(res.body.message).to.contain(
+            "Article ready to be posted on twitter"
+          );
+          done();
+        });
+    });
+    it("should be ready to be posted on facebook", done => {
+      chai
+        .request(app)
+        .get(`/api/v1/articles/${validSlug}/share/fb`)
+        .set("Authorization", `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).equals(OK);
+          expect(res.body.message).to.contain(
+            "Article ready to be posted on facebook"
+          );
+          done();
+        });
+    });
+    it("should be ready to be posted on linkedIn", done => {
+      chai
+        .request(app)
+        .get(`/api/v1/articles/${validSlug}/share/linkedIn`)
+        .set("Authorization", `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).equals(OK);
+          expect(res.body.message).to.contain(
+            "Article ready to be posted on linkedIn"
+          );
+          done();
+        });
+    });
+    it("should be ready to be posted on email", done => {
+      chai
+        .request(app)
+        .get(`/api/v1/articles/${validSlug}/share/email`)
+        .set("Authorization", `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).equals(OK);
+          expect(res.body.message).to.contain("Article ready to be posted on Email");
+          done();
+        });
+    });
+  });
+  describe("Fetching all articles", () => {
+    it("should return a list of all created articles", done => {
+      chai
+        .request(app)
+        .get(`/api/v1/articles`)
+        .set("Authorization", `Bearer ${token}`)
+        .end((err, res) => {
+          expect(res.status).equals(OK);
+          expect(res.body.message).to.contain("Successful");
+          expect(res.body)
+            .to.haveOwnProperty("articles")
+            .to.be.an("array");
+          expect(res.body)
+            .to.haveOwnProperty("articlesCount")
+            .to.be.a("number");
+          res.body.articles.map(article => {
+            expect(article).to.have.any.keys(
+              "slug",
+              "title",
+              "description",
+              "body",
+              "tagsList",
+              "favorited",
+              "favoritesCount",
+              "author"
+            );
+            expect(article.tagsList).to.be.an("array");
+            expect(article.favoritesCount).to.be.a("number");
+            expect(article.favorited).to.be.a("boolean");
+            return expect(article.author)
+              .to.be.an("object")
+              .to.haveOwnProperty("username")
+              .to.be.a("string");
           });
-      });
+        });
 
       it("should deny bookmarking if no access-token provided", done => {
         const { article } = createdArticle;

--- a/tests/integration/article.test.js
+++ b/tests/integration/article.test.js
@@ -141,7 +141,6 @@ describe("# Articles endpoints", () => {
         .set("Authorization", `Bearer ${token}`)
         .send({ description: "abusive" })
         .end((err, res) => {
-          console.log("FDJVGHDFJICHGIJSDHJDFJJG", res.body);
           expect(res.status).equals(OK);
           expect(res.body.message).to.contain("Article reported");
           done();

--- a/tests/integration/article.test.js
+++ b/tests/integration/article.test.js
@@ -34,7 +34,6 @@ before(done => {
 });
 
 describe("# Articles endpoints", () => {
-  let createdArticle;
   describe("Create a new article", () => {
     it("should create the article and return the success message", done => {
       chai
@@ -43,7 +42,6 @@ describe("# Articles endpoints", () => {
         .set("Authorization", `Bearer ${token}`)
         .send(newArticle)
         .end((err, res) => {
-          createdArticle = res.body;
           validSlug = res.body.article.slug;
           expect(res.status).equals(CREATED);
           expect(res.body.message).to.contain("Article created");
@@ -124,160 +122,6 @@ describe("# Articles endpoints", () => {
           expect(res.body.article).to.haveOwnProperty("createdAt");
           expect(res.body.article).to.haveOwnProperty("title");
           expect(res.body.article.title).to.contain(newArticle.title);
-          done();
-        });
-    });
-  });
-
-  describe("Report an article endpoint", () => {
-    it("should be report an article", done => {
-      chai
-        .request(app)
-        .put(`/api/v1/articles/${validSlug}/report`)
-        .set("Authorization", `Bearer ${token}`)
-        .send({ description: "abusive" })
-        .end((err, res) => {
-          expect(res.status).equals(OK);
-          expect(res.body.message).to.contain("Article reported");
-          done();
-        });
-    });
-
-    it("should report an article", done => {
-      chai
-        .request(app)
-        .put(`/api/v1/articles/${validSlug}/report`)
-        .set("Authorization", `Bearer ${token}`)
-        .send({ description: "abusive" })
-        .end((err, res) => {
-          expect(res.status).equals(OK);
-          expect(res.body.message).to.contain("Article reported");
-          done();
-        });
-    });
-
-    it("should should ask for description", done => {
-      chai
-        .request(app)
-        .put(`/api/v1/articles/${validSlug}/report`)
-        .set("Authorization", `Bearer ${token}`)
-        .send({ description: "" })
-        .end((err, res) => {
-          expect(res.status).equals(BAD_REQUEST);
-          expect(res.body.message).to.contain("Please, give a reason");
-          done();
-        });
-    });
-  });
-
-  describe("POST /articles/:slug/bookmark", () => {
-    it("should bookmark the article and return the success message", done => {
-      const { article } = createdArticle;
-      chai
-        .request(app)
-        .post(`/api/v1/articles/${article.slug}/bookmark`)
-        .set("Authorization", `Bearer ${token}`)
-        .end((err, res) => {
-          expect(res.status).equals(CREATED);
-          expect(res.body.message).to.contain("Article bookmarked");
-          expect(res.body).to.haveOwnProperty("bookmark");
-          expect(res.body.bookmark).to.be.an("object");
-          expect(res.body.bookmark).to.haveOwnProperty("createdAt");
-          expect(res.body.bookmark.articleId).equals(article.id);
-          done();
-        });
-    });
-
-    it("should deny bookmarking if no access-token provided", done => {
-      const { article } = createdArticle;
-      chai
-        .request(app)
-        .post(`/api/v1/articles/${article.slug}/bookmark`)
-        .end((err, res) => {
-          expect(res.status).equals(UNAUTHORIZED);
-          expect(res.body.message).to.contain("Please provide a token");
-          done();
-        });
-    });
-
-    it("should decline bookmarking the article which doesn't exist", done => {
-      const { article } = createdArticle;
-      chai
-        .request(app)
-        .post(`/api/v1/articles/${article.slug}fs1/bookmark`)
-        .set("Authorization", `Bearer ${token}`)
-        .end((err, res) => {
-          expect(res.status).equals(NOT_FOUND);
-          expect(res.body.message).to.contain("The article with this slug");
-          done();
-        });
-    });
-
-    it("should delete the bookmark if it existed", done => {
-      const { article } = createdArticle;
-      chai
-        .request(app)
-        .post(`/api/v1/articles/${article.slug}/bookmark`)
-        .set("Authorization", `Bearer ${token}`)
-        .end((err, res) => {
-          expect(res.status).equals(OK);
-          expect(res.body.message).to.contain("Bookmark deleted");
-          done();
-        });
-    });
-  });
-
-  describe("Share Articles endpoints", () => {
-    it("should be ready to be posted on twitter", done => {
-      chai
-        .request(app)
-        .get(`/api/v1/articles/${validSlug}/share/twitter`)
-        .set("Authorization", `Bearer ${token}`)
-        .end((err, res) => {
-          expect(res.status).equals(OK);
-          expect(res.body.message).to.contain(
-            "Article ready to be posted on twitter"
-          );
-          done();
-        });
-    });
-
-    it("should be ready to be posted on facebook", done => {
-      chai
-        .request(app)
-        .get(`/api/v1/articles/${validSlug}/share/fb`)
-        .set("Authorization", `Bearer ${token}`)
-        .end((err, res) => {
-          expect(res.status).equals(OK);
-          expect(res.body.message).to.contain(
-            "Article ready to be posted on facebook"
-          );
-          done();
-        });
-    });
-
-    it("should be ready to be posted on linkedIn", done => {
-      chai
-        .request(app)
-        .get(`/api/v1/articles/${validSlug}/share/linkedIn`)
-        .set("Authorization", `Bearer ${token}`)
-        .end((err, res) => {
-          expect(res.status).equals(OK);
-          expect(res.body.message).to.contain(
-            "Article ready to be posted on linkedIn"
-          );
-          done();
-        });
-    });
-
-    it("should be ready to be posted on email", done => {
-      chai
-        .request(app)
-        .get(`/api/v1/articles/${validSlug}/share/email`)
-        .set("Authorization", `Bearer ${token}`)
-        .end((err, res) => {
-          expect(res.status).equals(OK);
-          expect(res.body.message).to.contain("Article ready to be posted on Email");
           done();
         });
     });

--- a/tests/integration/article.test.js
+++ b/tests/integration/article.test.js
@@ -316,6 +316,7 @@ describe("# Articles endpoints", () => {
               .to.be.a("string");
           });
         });
+      });
 
       it("should deny bookmarking if no access-token provided", done => {
         const { article } = createdArticle;

--- a/tests/integration/articleLikes.test.js
+++ b/tests/integration/articleLikes.test.js
@@ -2,9 +2,7 @@ import chai, { expect } from "chai";
 import chaiHttp from "chai-http";
 import app from "../../index";
 import { article, users } from "../helpers/testData";
-import constants from "../../helpers/constants";
 
-const { OK, CREATED, NOT_FOUND, UNAUTHORIZED } = constants.statusCode;
 chai.use(chaiHttp);
 const { dummyUser } = users;
 describe("ArticleLike Controller", () => {
@@ -44,7 +42,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(CREATED);
+            expect(response.status).eql(201);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
             expect(response.body.message).to.be.eql("Successfully liked");
@@ -61,7 +59,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(OK);
+            expect(response.status).eql(200);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
             expect(response.body.message).to.be.eql("Disliked successfully");
@@ -80,7 +78,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(NOT_FOUND);
+            expect(response.status).eql(404);
             expect(response.body).to.an("object");
             expect(response.body)
               .to.have.property("message")
@@ -98,7 +96,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(UNAUTHORIZED);
+            expect(response.status).eql(401);
             done();
           });
       });
@@ -114,7 +112,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(CREATED);
+            expect(response.status).eql(201);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
             expect(response.body.message).to.be.eql("Successfully disliked");
@@ -131,7 +129,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(OK);
+            expect(response.status).eql(200);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
             expect(response.body.message).to.be.eql("Successfully removed dislike");
@@ -150,7 +148,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(NOT_FOUND);
+            expect(response.status).eql(404);
             expect(response.body).to.an("object");
             expect(response.body)
               .to.have.property("message")
@@ -168,7 +166,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(UNAUTHORIZED);
+            expect(response.status).eql(401);
             done();
           });
       });
@@ -184,7 +182,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(OK);
+            expect(response.status).eql(200);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("article");
             expect(response.body.article).to.have.property("id");
@@ -209,7 +207,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(NOT_FOUND);
+            expect(response.status).eql(404);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
             expect(response.body.message).eql("Article not found");
@@ -226,7 +224,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(UNAUTHORIZED);
+            expect(response.status).eql(401);
             done();
           });
       });

--- a/tests/integration/articleLikes.test.js
+++ b/tests/integration/articleLikes.test.js
@@ -2,9 +2,13 @@ import chai, { expect } from "chai";
 import chaiHttp from "chai-http";
 import app from "../../index";
 import { article, users } from "../helpers/testData";
+import constants from "../../helpers/constants";
+
+const { OK, CREATED, NOT_FOUND, UNAUTHORIZED } = constants.statusCode;
+const { dummyUser } = users;
 
 chai.use(chaiHttp);
-const { dummyUser } = users;
+
 describe("ArticleLike Controller", () => {
   let slug;
   let token;
@@ -42,7 +46,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(201);
+            expect(response.status).eql(CREATED);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
             expect(response.body.message).to.be.eql("Successfully liked");
@@ -59,7 +63,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(200);
+            expect(response.status).eql(OK);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
             expect(response.body.message).to.be.eql("Disliked successfully");
@@ -78,7 +82,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(404);
+            expect(response.status).eql(NOT_FOUND);
             expect(response.body).to.an("object");
             expect(response.body)
               .to.have.property("message")
@@ -96,7 +100,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(401);
+            expect(response.status).eql(UNAUTHORIZED);
             done();
           });
       });
@@ -112,7 +116,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(201);
+            expect(response.status).eql(CREATED);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
             expect(response.body.message).to.be.eql("Successfully disliked");
@@ -129,7 +133,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(200);
+            expect(response.status).eql(OK);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
             expect(response.body.message).to.be.eql("Successfully removed dislike");
@@ -148,7 +152,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(404);
+            expect(response.status).eql(NOT_FOUND);
             expect(response.body).to.an("object");
             expect(response.body)
               .to.have.property("message")
@@ -166,7 +170,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(401);
+            expect(response.status).eql(UNAUTHORIZED);
             done();
           });
       });
@@ -182,7 +186,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(200);
+            expect(response.status).eql(OK);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("article");
             expect(response.body.article).to.have.property("id");
@@ -207,7 +211,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(404);
+            expect(response.status).eql(NOT_FOUND);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
             expect(response.body.message).eql("Article not found");
@@ -224,7 +228,7 @@ describe("ArticleLike Controller", () => {
             if (err) {
               return done(err);
             }
-            expect(response.status).eql(401);
+            expect(response.status).eql(UNAUTHORIZED);
             done();
           });
       });

--- a/tests/integration/articleLikes.test.js
+++ b/tests/integration/articleLikes.test.js
@@ -64,7 +64,7 @@ describe("ArticleLike Controller", () => {
             expect(response.status).eql(OK);
             expect(response.body).to.an("object");
             expect(response.body).to.have.property("message");
-            expect(response.body.message).to.be.eql("Unliked successfully");
+            expect(response.body.message).to.be.eql("Disliked successfully");
             done();
           });
       });

--- a/tests/integration/bookmarkController.test.js
+++ b/tests/integration/bookmarkController.test.js
@@ -4,7 +4,7 @@ import app from "../../index";
 import constants from "../../helpers/constants";
 import { post, token } from "../setups.test";
 
-const { UNAUTHORIZED, CREATED, NOT_FOUND, GONE } = constants.statusCode;
+const { UNAUTHORIZED, CREATED, NOT_FOUND, OK } = constants.statusCode;
 chai.use(chaiHttp);
 
 describe("POST /articles/:slug/bookmark", () => {
@@ -53,7 +53,7 @@ describe("POST /articles/:slug/bookmark", () => {
       .post(`/api/v1/articles/${post.slug}/bookmark`)
       .set("Authorization", `Bearer ${token}`)
       .end((err, res) => {
-        expect(res.status).equals(GONE);
+        expect(res.status).equals(OK);
         expect(res.body.message).to.contain("Bookmark deleted");
         done();
       });

--- a/tests/integration/likecomment.test.js
+++ b/tests/integration/likecomment.test.js
@@ -77,7 +77,7 @@ describe("Liking a comment", () => {
         });
     });
 
-    it("should unlike the comment and return the comment unliked message", done => {
+    it("should unlike the comment and return the comment Disliked message", done => {
       chai
         .request(app)
         .post(`/api/v1/articles/${slug}/comments/${commentId}/likes`)
@@ -85,7 +85,7 @@ describe("Liking a comment", () => {
         .end((err, res) => {
           if (err) done(err);
           expect(res.status).equals(CREATED);
-          expect(res.body.message).to.contain("Comment unliked");
+          expect(res.body.message).to.contain("Comment Disliked");
           done();
         });
     });

--- a/tests/integration/reportArticleController.test.js
+++ b/tests/integration/reportArticleController.test.js
@@ -4,7 +4,7 @@ import app from "../../index";
 import { post, token } from "../setups.test";
 import constants from "../../helpers/constants";
 
-const { BAD_REQUEST, OK, CONFLICT } = constants.statusCode;
+const { BAD_REQUEST, OK } = constants.statusCode;
 
 chai.use(chaiHttp);
 describe("Report an article endpoint", () => {
@@ -20,6 +20,7 @@ describe("Report an article endpoint", () => {
         done();
       });
   });
+
   it("should report an article", done => {
     chai
       .request(app)
@@ -27,11 +28,12 @@ describe("Report an article endpoint", () => {
       .set("Authorization", `Bearer ${token}`)
       .send({ description: "abusive" })
       .end((err, res) => {
-        expect(res.status).equals(CONFLICT);
+        expect(res.status).equals(OK);
         expect(res.body.message).to.contain("Article already reported");
         done();
       });
   });
+
   it("should should ask for description", done => {
     chai
       .request(app)


### PR DESCRIPTION
#### What does this PR do?
- It fetches all articles with pagination support
#### Description of Task to be completed?
- The user should be able to read articles created by other users with pagination support
#### How should this be manually tested?
- After cloning the repository, check out `ft-articles-pagination-endpoints-163518696` branch
- Make sure to read `README.md` file to get the setup instructions
- Using any `API client tool(usually POSTMAN)`,
- Create the user and login to get the `access-token`
- Create some articles using `POST /api/v1/articles` endpoint
- Make sure to pass the token under `request headers`. It should be {`Authorization`: `Bearer <access-token>`} KEY, VALUE PAIR
- the request body should be as mentioned in the `README.md` file under `Endpoints:` ==> `Create Article` subtitle
After the successful article(s) creation,
- You also can fetch all articles using `GET /api/v1/articles`

The `GET /api/v1/articles`  returns most recent articles globally. You can pass the `page=x` param where `x` is the page number(x=1 by default) and/or the `limit=y` where `y` is the maximum number of articles(y=20 by default) you want to get back.
 
#### Any background context you want to provide?
- The pagination context defined in the README.md file was to use `offset` query param in place of `page`, but I decided to use the `page` because it is obvious and makes sense than `offset`.
- This API endpoint can be accessed by any user and it doesn't require the user to be logged in
#### What are the relevant pivotal tracker stories?
- #163518696