### PR TITLE
#165713051 Change Password

### DIFF
--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -281,7 +281,7 @@ class UserController {
         return res.status(NOT_FOUND).json({ message: "User not found" });
       }
       if (usernameFromToken !== username) {
-        return res.status(UNAUTHORIZED).json({ error: "Not authorized" });
+        return res.status(UNAUTHORIZED).json({ message: "Not authorized" });
       }
       const newPWdMatchCurrent = await compareSync(
         currentPassword,

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -270,9 +270,8 @@ class UserController {
         user: { username: usernameFromToken },
         params: { username }
       } = req;
-      const salt = await genSaltSync(
-        parseFloat(process.env.BCRYPT_HASH_ROUNDS) || 10
-      );
+      const { BCRYPT_HASH_ROUNDS } = process.env;
+      const salt = await genSaltSync(parseFloat(BCRYPT_HASH_ROUNDS) || 10);
       const response = await User.findOne({ where: { username } });
 
       const newHashedPassword = await hashSync(newPassword, salt);

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -262,6 +262,40 @@ class UserController {
       });
     }
   }
+
+  static async changePassword(req, res) {
+    try {
+      const { newPassword, currentPassword } = req.body;
+      const { username } = req.params;
+      const salt = await genSaltSync(
+        parseFloat(process.env.BCRYPT_HASH_ROUNDS) || 10
+      );
+      const response = await User.findOne({ where: { username } });
+
+      const newHashedPassword = await hashSync(newPassword, salt);
+
+      if (!response) {
+        return res.status(NOT_FOUND).json({ message: "User not found" });
+      }
+      const newPWdMatchCurrent = await compareSync(
+        currentPassword,
+        response.password
+      );
+      if (!newPWdMatchCurrent) {
+        return res.status(BAD_REQUEST).json({
+          message: "Invalid Current Password"
+        });
+      }
+      await User.update({ password: newHashedPassword }, { where: { username } });
+      return res.status(OK).json({ message: "Password updated successfully" });
+    } catch (error) {
+      res.status(INTERNAL_SERVER_ERROR).json({
+        message: "Password update failed",
+        errors:
+          "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
+      });
+    }
+  }
 }
 
 export default UserController;

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -265,22 +265,24 @@ class UserController {
 
   static async changePassword(req, res) {
     try {
-      const { newPassword, currentPassword } = req.body;
-      const usernameFromToken = req.user.username;
-      const { username } = req.params;
+      const {
+        body: { newPassword, currentPassword },
+        user: { username: usernameFromToken },
+        params: { username }
+      } = req;
       const salt = await genSaltSync(
         parseFloat(process.env.BCRYPT_HASH_ROUNDS) || 10
       );
       const response = await User.findOne({ where: { username } });
 
       const newHashedPassword = await hashSync(newPassword, salt);
-     
+
       if (!response) {
         return res.status(NOT_FOUND).json({ message: "User not found" });
       }
       if (usernameFromToken !== username) {
         return res.status(UNAUTHORIZED).json({ error: "Not authorized" });
-      }  
+      }
       const newPWdMatchCurrent = await compareSync(
         currentPassword,
         response.password

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -296,8 +296,7 @@ class UserController {
       return res.status(OK).json({ message: "Password updated successfully" });
     } catch (error) {
       res.status(INTERNAL_SERVER_ERROR).json({
-        message: "Password update failed",
-        errors:
+        message:
           "Sorry, this is not working properly. We now know about this mistake and are working to fix it"
       });
     }

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -266,6 +266,7 @@ class UserController {
   static async changePassword(req, res) {
     try {
       const { newPassword, currentPassword } = req.body;
+      const usernameFromToken = req.user.username;
       const { username } = req.params;
       const salt = await genSaltSync(
         parseFloat(process.env.BCRYPT_HASH_ROUNDS) || 10
@@ -273,10 +274,13 @@ class UserController {
       const response = await User.findOne({ where: { username } });
 
       const newHashedPassword = await hashSync(newPassword, salt);
-
+     
       if (!response) {
         return res.status(NOT_FOUND).json({ message: "User not found" });
       }
+      if (usernameFromToken !== username) {
+        return res.status(UNAUTHORIZED).json({ error: "Not authorized" });
+      }  
       const newPWdMatchCurrent = await compareSync(
         currentPassword,
         response.password

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ app.use((err, req, res, next) => {
     message: err.message
   });
 });
-const server = app.listen(process.env.PORT || 4000, () => {
+const server = app.listen(process.env.PORT || 3000, () => {
   console.log(`Listening on port ${server.address().port}`);
 });
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ app.use((err, req, res, next) => {
     message: err.message
   });
 });
-const server = app.listen(process.env.PORT || 3000, () => {
+const server = app.listen(process.env.PORT || 4000, () => {
   console.log(`Listening on port ${server.address().port}`);
 });
 

--- a/middlewares/signupValidator.js
+++ b/middlewares/signupValidator.js
@@ -25,7 +25,12 @@ export default class SignupValidator {
   }
 
   static validateNewPassword(req, res, next) {
-    const { newPassword } = req.body;
+    const { newPassword, currentPassword } = req.body;
+    if (newPassword === null || currentPassword === null) {
+      return res.status(BAD_REQUEST).json({
+        message: "Null values are not allowed!"
+      });
+    }
     const isPassword = isAlphanumeric(newPassword) && newPassword.trim().length >= 8;
     return isPassword
       ? next()

--- a/middlewares/signupValidator.js
+++ b/middlewares/signupValidator.js
@@ -24,6 +24,17 @@ export default class SignupValidator {
       : res.status(BAD_REQUEST).json({ message: "Invalid email" });
   }
 
+  static validateNewPassword(req, res, next) {
+    const { newPassword } = req.body;
+    const isPassword = isAlphanumeric(newPassword) && newPassword.trim().length >= 8;
+    return isPassword
+      ? next()
+      : res.status(BAD_REQUEST).json({
+          message:
+            "The password should be an alphanumeric with at least 8 characters"
+        });
+  }
+
   static validatePassword(req, res, next) {
     const { password } = req.body;
     const isPassword = isAlphanumeric(password) && password.trim().length >= 8;

--- a/middlewares/signupValidator.js
+++ b/middlewares/signupValidator.js
@@ -26,11 +26,6 @@ export default class SignupValidator {
 
   static validateNewPassword(req, res, next) {
     const { newPassword, currentPassword } = req.body;
-    if (newPassword === null || currentPassword === null) {
-      return res.status(BAD_REQUEST).json({
-        message: "Null values are not allowed!"
-      });
-    }
     if (!currentPassword || !newPassword) {
       return res.status(BAD_REQUEST).json({
         message: "Current and new password are required fields"

--- a/middlewares/signupValidator.js
+++ b/middlewares/signupValidator.js
@@ -31,6 +31,11 @@ export default class SignupValidator {
         message: "Null values are not allowed!"
       });
     }
+    if (!currentPassword || !newPassword) {
+      return res.status(BAD_REQUEST).json({
+        message: "Current and new password are required fields"
+      });
+    }
     const isPassword = isAlphanumeric(newPassword) && newPassword.trim().length >= 8;
     return isPassword
       ? next()

--- a/routes/users.js
+++ b/routes/users.js
@@ -8,7 +8,6 @@ import checkAuth from "../middlewares/checkAuth";
 import NotificationController from "../controllers/notificationController";
 import validator from "../middlewares/modelValidator";
 
-
 const userRouters = Router();
 
 userRouters.get("/users/confirm/:auth_token", UserController.confirmation);
@@ -28,6 +27,12 @@ userRouters
     "/users/:token/password",
     SignupValidation.validatePassword,
     UserController.updatePassword
+  )
+  .put(
+    "/users/password/:username/change",
+    checkAuth,
+    SignupValidation.validateNewPassword,
+    UserController.changePassword
   )
   .put(
     "/users/:username/roles/:roleId",

--- a/routes/users.js
+++ b/routes/users.js
@@ -29,7 +29,7 @@ userRouters
     UserController.updatePassword
   )
   .put(
-    "/users/password/:username/change",
+    "/users/:username/password/change",
     checkAuth,
     SignupValidation.validateNewPassword,
     UserController.changePassword

--- a/tests/integration/updatePassword.test.js
+++ b/tests/integration/updatePassword.test.js
@@ -33,7 +33,9 @@ describe("Change Password", () => {
       .set("Authorization", `Bearer ${token}`)
       .send({ newPassword: null, currentPassword: null });
     expect(results.status).equal(BAD_REQUEST);
-    expect(results.body.message).equal("Null values are not allowed!");
+    expect(results.body.message).equal(
+      "Current and new password are required fields"
+    );
   });
 
   it("should fail on non alphanumeric password", async () => {

--- a/tests/integration/updatePassword.test.js
+++ b/tests/integration/updatePassword.test.js
@@ -11,25 +11,27 @@ describe("Change Password", () => {
   it("should return user not found", async () => {
     const results = await chai
       .request(app)
-      .put(`/api/v1/users/password/jjgjdmr/change`)
+      .put(`/api/v1/users/jjgjdmr/password/change`)
       .set("Authorization", `Bearer ${token}`)
       .send({ newPassword: "jdkskkfksk343", currentPassword: "lucjdldf2018" });
     expect(results.status).equal(NOT_FOUND);
     expect(results.body.message).equal("User not found");
   });
+
   it("should return Invalid Current Password", async () => {
     const results = await chai
       .request(app)
-      .put(`/api/v1/users/password/${user.username}/change`)
+      .put(`/api/v1/users/${user.username}/password/change`)
       .set("Authorization", `Bearer ${token}`)
       .send({ newPassword: "jdkskkfksk343", currentPassword: "lucjldf2018" });
     expect(results.status).equal(BAD_REQUEST);
     expect(results.body.message).equal("Invalid Current Password");
   });
+
   it("should return null not allowed", async () => {
     const results = await chai
       .request(app)
-      .put(`/api/v1/users/password/${user.username}/change`)
+      .put(`/api/v1/users/${user.username}/password/change`)
       .set("Authorization", `Bearer ${token}`)
       .send({ newPassword: null, currentPassword: null });
     expect(results.status).equal(BAD_REQUEST);
@@ -41,7 +43,7 @@ describe("Change Password", () => {
   it("should fail on non alphanumeric password", async () => {
     const results = await chai
       .request(app)
-      .put(`/api/v1/users/password/${user.username}/change`)
+      .put(`/api/v1/users/${user.username}/password/change`)
       .set("Authorization", `Bearer ${token}`)
       .send({ newPassword: "jdksk", currentPassword: user.password });
     expect(results.status).equal(BAD_REQUEST);
@@ -53,16 +55,17 @@ describe("Change Password", () => {
   it("should return un-authorized", async () => {
     const results = await chai
       .request(app)
-      .put(`/api/v1/users/password/${user2.username}/change`)
+      .put(`/api/v1/users/${user2.username}/password/change`)
       .set("Authorization", `Bearer ${token}`)
       .send({ newPassword: "jdkskkfksk343", currentPassword: "password78t67" });
 
     expect(results.status).equal(UNAUTHORIZED);
   });
+
   it("should require both new and current password", async () => {
     const results = await chai
       .request(app)
-      .put(`/api/v1/users/password/${user.username}/change`)
+      .put(`/api/v1/users/${user.username}/password/change`)
       .set("Authorization", `Bearer ${token}`)
       .send({});
 
@@ -71,10 +74,11 @@ describe("Change Password", () => {
       "Current and new password are required fields"
     );
   });
+
   it("should update password", async () => {
     const results = await chai
       .request(app)
-      .put(`/api/v1/users/password/${user.username}/change`)
+      .put(`/api/v1/users/${user.username}/password/change`)
       .set("Authorization", `Bearer ${token}`)
       .send({ newPassword: "jdkskkfksk343", currentPassword: "password78t67" });
     expect(results.status).equal(OK);

--- a/tests/integration/updatePassword.test.js
+++ b/tests/integration/updatePassword.test.js
@@ -2,16 +2,16 @@ import chaiHttp from "chai-http";
 import chai, { expect, should } from "chai";
 import app from "../../index";
 import constants from "../../helpers/constants";
-import { user, token } from "../setups.test";
+import { user, user2, token } from "../setups.test";
 
-const { OK, NOT_FOUND, BAD_REQUEST } = constants.statusCode;
+const { OK, NOT_FOUND, BAD_REQUEST, UNAUTHORIZED } = constants.statusCode;
 chai.use(chaiHttp);
 should();
 describe("Change Password", () => {
   it("should return user not found", async () => {
     const results = await chai
       .request(app)
-      .put(`/api/v1/users/password/${"jjgjdmr"}/change`)
+      .put(`/api/v1/users/password/jjgjdmr/change`)
       .set("Authorization", `Bearer ${token}`)
       .send({ newPassword: "jdkskkfksk343", currentPassword: "lucjdldf2018" });
     expect(results.status).equal(NOT_FOUND);
@@ -26,6 +26,15 @@ describe("Change Password", () => {
     expect(results.status).equal(BAD_REQUEST);
     expect(results.body.message).equal("Invalid Current Password");
   });
+  it("should return null not allowed", async () => {
+    const results = await chai
+      .request(app)
+      .put(`/api/v1/users/password/${user.username}/change`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ newPassword: null, currentPassword: null });
+    expect(results.status).equal(BAD_REQUEST);
+    expect(results.body.message).equal("Null values are not allowed!");
+  });
 
   it("should fail on non alphanumeric password", async () => {
     const results = await chai
@@ -39,6 +48,15 @@ describe("Change Password", () => {
     );
   });
 
+  it("should return un-authorized", async () => {
+    const results = await chai
+      .request(app)
+      .put(`/api/v1/users/password/${user2.username}/change`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ newPassword: "jdkskkfksk343", currentPassword: "password78t67" });
+
+    expect(results.status).equal(UNAUTHORIZED);
+  });
   it("should update password", async () => {
     const results = await chai
       .request(app)

--- a/tests/integration/updatePassword.test.js
+++ b/tests/integration/updatePassword.test.js
@@ -1,0 +1,52 @@
+import chaiHttp from "chai-http";
+import chai, { expect, should } from "chai";
+import app from "../../index";
+import constants from "../../helpers/constants";
+import { user, token } from "../setups.test";
+
+const { OK, NOT_FOUND, BAD_REQUEST } = constants.statusCode;
+chai.use(chaiHttp);
+should();
+describe("Change Password", () => {
+  it("should return user not found", async () => {
+    const results = await chai
+      .request(app)
+      .put(`/api/v1/users/password/${"jjgjdmr"}/change`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ newPassword: "jdkskkfksk343", currentPassword: "lucjdldf2018" });
+    expect(results.status).equal(NOT_FOUND);
+    expect(results.body.message).equal("User not found");
+  });
+  it("should return Invalid Current Password", async () => {
+    const results = await chai
+      .request(app)
+      .put(`/api/v1/users/password/${user.username}/change`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ newPassword: "jdkskkfksk343", currentPassword: "lucjldf2018" });
+    expect(results.status).equal(BAD_REQUEST);
+    expect(results.body.message).equal("Invalid Current Password");
+  });
+
+  it("should fail on non alphanumeric password", async () => {
+    const results = await chai
+      .request(app)
+      .put(`/api/v1/users/password/${user.username}/change`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ newPassword: "jdksk", currentPassword: user.password });
+    expect(results.status).equal(BAD_REQUEST);
+    expect(results.body.message).equal(
+      "The password should be an alphanumeric with at least 8 characters"
+    );
+  });
+
+  it("should update password", async () => {
+    const results = await chai
+      .request(app)
+      .put(`/api/v1/users/password/${user.username}/change`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ newPassword: "jdkskkfksk343", currentPassword: "password78t67" });
+
+    expect(results.status).equal(OK);
+    expect(results.body.message).equal("Password updated successfully");
+  });
+});

--- a/tests/integration/updatePassword.test.js
+++ b/tests/integration/updatePassword.test.js
@@ -57,13 +57,24 @@ describe("Change Password", () => {
 
     expect(results.status).equal(UNAUTHORIZED);
   });
+  it("should require both new and current password", async () => {
+    const results = await chai
+      .request(app)
+      .put(`/api/v1/users/password/${user.username}/change`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+
+    expect(results.status).equal(BAD_REQUEST);
+    expect(results.body.message).equal(
+      "Current and new password are required fields"
+    );
+  });
   it("should update password", async () => {
     const results = await chai
       .request(app)
       .put(`/api/v1/users/password/${user.username}/change`)
       .set("Authorization", `Bearer ${token}`)
       .send({ newPassword: "jdkskkfksk343", currentPassword: "password78t67" });
-
     expect(results.status).equal(OK);
     expect(results.body.message).equal("Password updated successfully");
   });


### PR DESCRIPTION
#### What does this PR do?

- It let users change the password when they are authenticated

#### Description of Task to be completed?
- Once you are logged in, you can change the password by providing the current password.
#### How should this be manually tested?
- After cloning the repository, check out `ft-change-password-#23165713051` branch
- Using any `API client tool(usually POSTMAN)`,
- Create the user and login to get the `access-token`
- Change password using `PUT /users/password/{username}/change` by providing the `currentPassword and newPassword` in the body of request
- Make sure to pass the token under `request headers`. It should be {`Authorization`: `Bearer <access-token>`} KEY, VALUE PAIR

#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
- #165713051