### PR TITLE
fix add order when fetching

### DIFF
--- a/controllers/commentController.js
+++ b/controllers/commentController.js
@@ -212,7 +212,7 @@ export default class CommentController {
               "like"
             ],
             offset: page,
-            limit: 20,
+            limit: 10,
             include: [
               {
                 model: User,

--- a/controllers/commentController.js
+++ b/controllers/commentController.js
@@ -233,7 +233,6 @@ export default class CommentController {
           .status(NOT_FOUND)
           .json({ message: "There is no article with that slug" });
       }
-      console.log(article.comments.length, "======");
       res.status(OK).json({ article });
     } catch (error) {
       res.status(INTERNAL_SERVER_ERROR).json({ message: error.message });

--- a/controllers/commentController.js
+++ b/controllers/commentController.js
@@ -198,6 +198,7 @@ export default class CommentController {
       const { page } = req.query;
       const article = await Article.findOne({
         where: { slug },
+        order: [["createdAt", "DESC"]],
         include: [
           {
             model: Comment,
@@ -232,6 +233,7 @@ export default class CommentController {
           .status(NOT_FOUND)
           .json({ message: "There is no article with that slug" });
       }
+      console.log(article.comments.length, "======");
       res.status(OK).json({ article });
     } catch (error) {
       res.status(INTERNAL_SERVER_ERROR).json({ message: error.message });


### PR DESCRIPTION
#### What does this PR do?

- add order when fetching

#### Description of Task to be completed?
-  Adds order on the date when fetching comments

#### How should this be manually tested?
- After cloning the repository, check out `bg-fix-add-order-on-fetch` branch
- Using any `API client tool(usually POSTMAN)`,
- Make sure to pass the token under `request headers`. It should be {`Authorization`: `Bearer <access-token>`} KEY, VALUE PAIR

#### Any background context you want to provide?
- None

#### What are the relevant pivotal tracker stories?